### PR TITLE
feat: SF-App-parity settings for Fan + Light, periodic config polling

### DIFF
--- a/docs/extending.md
+++ b/docs/extending.md
@@ -1,0 +1,281 @@
+# Extending the Bridge — Adding New Modules / Settings to HA
+
+Practical playbook for the next time the SF App grows a new screen, or the
+controller gains a new field we want exposed in Home Assistant. Pairs with
+[`sf-protocol.md`](sf-protocol.md), which is the protocol reference; this
+doc is the recipe.
+
+The fan and light app-parity work (`feat/fan-app-parity`) is the canonical
+worked example — read those diffs alongside this guide.
+
+---
+
+## Architecture in 30 seconds
+
+Three layers, three files, one direction each:
+
+```
+device → cloud  ┐
+                ├─►  proxy/normalizer.py  ─►  HA state topics
+HA → device     │    proxy/command_handler.py  ─►  setConfigField
+                └    ha/discovery.py  ─►  HA MQTT discovery
+```
+
+- **`proxy/normalizer.py`** — turns whatever shape the controller sends
+  (`getDevSta` / `getConfigField` response / observed cloud
+  `setConfigField`) into flat `state/...` topics for HA.
+- **`proxy/command_handler.py`** — turns HA `command/.../set` payloads
+  into `setConfigField` requests for the controller.
+- **`ha/discovery.py`** — emits the static MQTT-discovery configs telling
+  HA which entities exist and which topics they live on.
+
+`proxy/mitm_proxy.py` glues these together. You usually don't need to
+touch it — it already caches observed cloud state in
+`session.fan_state` / `session.light_state` / `session.device_state`,
+publishes per-field state on cache write, and routes incoming
+`/command/<field>/<subfield>/set` topics to `translate_command`.
+
+---
+
+## Step 0 — Capture real traffic first
+
+Never invent field names. Capture what the SF App actually sends and the
+controller actually returns.
+
+1. Set the controller to talk through the proxy (DNS hijack already in
+   place if the bridge is running).
+2. Tail the proxy log and filter for the module you care about:
+   ```bash
+   ssh pi@<host> 'pm2 logs spiderbridge-proxy --lines 0' | grep -i 'setConfigField\|<module>'
+   ```
+3. In the SF App, click through every option on the new screen — every
+   toggle, slider, mode dropdown. Watch each click produce one
+   `setConfigField` capture.
+4. Save the JSON for later. The interesting bits are the **`params.<module>`
+   block** (full field set) and `params.keyPath` (`["device", "<module>"]`
+   or `["outlet", "O3"]`).
+
+If `getConfigField` is supported for your module, also capture a
+CONFIG-RESP — the bridge already polls those every 10 minutes and on
+session connect, so they show up automatically once you enable polling
+for the new keypath (`MITMProxy.poll_session_config` in `mitm_proxy.py`).
+
+---
+
+## Step 1 — Decide the entity shape in HA
+
+Pick from the existing patterns:
+
+| Controller field type     | HA entity   | Helper in `discovery.py`      |
+|---------------------------|-------------|--------------------------------|
+| 0/1 toggle                | `switch`    | `_switch_path`                 |
+| Numeric (clamped range)   | `number`    | `_number_path`                 |
+| `HH:MM` time              | `text`      | `_text_path` (with regex)      |
+| Mode dropdown             | `select` or `fan.preset_modes` | inline   |
+| RGB / brightness          | `light`     | `_light` (json schema)         |
+| Read-only metric          | `sensor`    | `_sensor`                      |
+
+If the new screen has multiple settings groups (the SF App's "Lampe
+Einstellungen" splits into Schedule, PPFD, Temperaturschutz), use
+**sub-devices** so HA renders them as separate cards. See
+`_settings_subdevice()` and how `_fan_extras()` / `_light_extras()` use
+it: each card gets its own `identifiers` and a `via_device` pointing at
+the main controller.
+
+If a single field belongs in multiple cards (Temperaturschutz applies in
+both Schedule and PPFD modes), use `_number_path_aliased()` — same wire
+topics, distinct unique_ids, both cards stay synchronized.
+
+---
+
+## Step 2 — Normalizer (controller → HA state topics)
+
+In `proxy/normalizer.py`:
+
+1. If the new module is a **block** under `data.<module>` (like fan,
+   light), add a top-level entry in `normalize_status` and an
+   `<module>_extras_topics()` helper modeled on `fan_extras_topics` /
+   `light_extras_topics`. The helper publishes one MQTT topic per HA
+   entity under `spiderfarmer/{device_id}/state/<module>/<suffix>`.
+
+2. Use the **cache-merge pattern** when the controller reports partial
+   updates: minimal `getDevSta` carries only `{on, level}` for some
+   firmwares, so merge against the cached full block before publishing
+   extras:
+   ```python
+   merged = {**cache.get(module, {}), **block_from_devsta}
+   result.update(<module>_extras_topics(device_id, module, merged))
+   ```
+
+3. If the module needs a `mode_label` (preset_mode dropdown), keep the
+   `_FAN_MODES` / `_LIGHT_MODES` dict in the normalizer as the single
+   source of truth — the discovery and command_handler reverse-map from
+   it.
+
+4. Add tests in `tests/test_normalizer.py` covering: full block, partial
+   update with cache fallback, the mode_label mapping for every known
+   `modeType`.
+
+---
+
+## Step 3 — Discovery (HA entities)
+
+In `ha/discovery.py`:
+
+1. Add an `_<module>_extras()` function returning a list of
+   `(topic, payload)` tuples. Use the existing helpers — don't roll
+   your own.
+
+2. Wire it in `publish_discovery_for_device`:
+   ```python
+   entities.append(_<module>(device_id, ...))      # main entity
+   entities += _<module>_extras(device_id, ...)    # settings sub-devices
+   ```
+
+3. Sub-device naming convention:
+   `spiderfarmer_{device_id}_<module>_<group>` (e.g.
+   `spiderfarmer_ggs_1_light_schedule`). Matches the slug used in
+   `_settings_subdevice()`.
+
+4. Add tests in `tests/test_discovery.py`. The existing tests check:
+   the topics are emitted, sub-device `identifiers` and `via_device`
+   are correct, ranges and units match, retain flag is set. Mirror
+   that pattern.
+
+---
+
+## Step 4 — Command handler (HA → controller)
+
+In `proxy/command_handler.py`:
+
+1. Define a `_<MODULE>_SUBFIELDS = {...}` set of every entity suffix
+   the new HA card writes back to.
+
+2. Branch on `if field == "<module>" and subfield in _<MODULE>_SUBFIELDS`
+   **before** any catch-all branch for the same field.
+
+3. **Cache + synthesize fallback.** Always start from a copy of the
+   cached block so untouched fields survive the round-trip. When the
+   cache is empty, synthesize a sensible default block — partial
+   `setConfigField` payloads get silently rejected by some firmwares.
+   See the fan/light branches for templates.
+
+4. For numeric subfields: clamp to the range HA published in discovery.
+   For `HH:MM` text: use `_hhmm_to_seconds`. For mode dropdowns: reverse
+   lookup against the same dict the normalizer uses.
+
+5. Pass any new cache parameter through:
+   - Add `<module>_state: Optional[dict] = None` to `translate_command`.
+   - In `mitm_proxy.handle_command`, pass `<module>_state=session.<module>_state`.
+   - Add the cache field to `ProxySession.__init__`.
+   - In `relay_down` (cloud → device observation), populate the cache
+     when you see a setConfigField for the module, and publish the
+     normalizer's per-field state topics so HA stays in sync.
+   - In `handle_command` (HA → device), do the same optimistic update
+     after `session.inject(payload)` — HA shouldn't have to wait for
+     the next poll to see its own change.
+
+6. Tests in `tests/test_command_handler.py`: one per subfield (happy
+   path), clamping at min/max, invalid input → `None`, empty cache
+   synthesizes defaults, cached block fields untouched outside the
+   target subfield.
+
+---
+
+## Step 5 — Wire periodic config polling (if the module supports it)
+
+`MITMProxy.poll_session_config` in `mitm_proxy.py` already injects
+`getConfigField` for `light`, `light2`, `fan`, `blower` every 10 minutes
+and on session connect. If your new module returns useful data via
+`getConfigField`, add its keypath to that list:
+
+```python
+for keypath in (["device", "light"], ["device", "light2"],
+                ["device", "fan"], ["device", "blower"],
+                ["device", "<your_module>"]):
+```
+
+If the controller does **not** support `getConfigField` for that module
+(some don't — silent timeout), fall back to caching from observed cloud
+`setConfigField` traffic only. The fan/light pattern handles both.
+
+---
+
+## Step 6 — Sync to the addon path
+
+Anything you change under `proxy/` or `ha/` must be mirrored under
+`spiderbridge/app/proxy/` and `spiderbridge/app/ha/` for the HA OS addon.
+The two `mitm_proxy.py` files differ only in `_save_config()` (the addon
+writes `/data/devices.yaml` when running under HA OS). All other files
+are byte-identical — copy them straight over.
+
+```bash
+cp proxy/<file>.py spiderbridge/app/proxy/<file>.py
+cp ha/discovery.py spiderbridge/app/ha/discovery.py
+cp tests/test_<file>.py spiderbridge/app/tests/test_<file>.py
+```
+
+Run both test suites:
+
+```bash
+python -m pytest tests/                   # standalone
+cd spiderbridge/app && python -m pytest tests/   # addon
+```
+
+The addon adds `tests/test_config_ha.py` on top — that's expected.
+
+---
+
+## Step 7 — Verify on a real device
+
+The unit tests catch shape errors, not behavior. Final check:
+
+1. Push the branch to the Pi: `git push && ssh pi@<host> 'cd /opt/spiderbridge && git pull && pm2 restart all'`
+   (or follow whatever deploy flow `update.sh` does).
+2. Open HA → device page → confirm new entities appear and load values.
+3. Click each new entity. In the proxy log you should see one `setConfigField`
+   per click, with the field you just changed. Compare it to the SF App
+   capture from Step 0 — they should be byte-equivalent (modulo
+   `msgId` / `uid`).
+4. Wait 10 minutes (or restart the proxy). The first config poll should
+   bring the controller's current values back and HA should reflect them.
+5. Change the same setting from the SF App. The proxy logs should
+   observe it; HA should update within seconds via `relay_down`'s
+   cache + extras-topic publish.
+
+If a click in HA produces no observable change on the controller, 90% of
+the time the cause is one of:
+
+- Wrong DOWN topic prefix (PS5/PS10 use a different prefix than CB —
+  `session.down_topic_prefix` is learned from observed cloud commands).
+  Symptom: the inject leaves the proxy but the controller never executes
+  it. Fix: trigger one click from the SF App first so the prefix gets
+  learned.
+- Cache empty + synthesized defaults missing a required field. Symptom:
+  controller silently rejects (no echo, no state change). Fix: capture
+  the App's full payload from Step 0 and add the missing field to the
+  synthesized default block in `command_handler.py`.
+- The module's keypath isn't in `poll_session_config` and no observed
+  `setConfigField` has populated the cache yet. Symptom: first HA write
+  works (synthesized default), subsequent writes wipe other fields. Fix:
+  add the keypath to the poll list.
+
+---
+
+## Reference: the fan and light app-parity diffs
+
+These two features are the worked examples to copy from. They cover all
+three layers, both standalone + addon paths, both modes of cache
+population (poll + cloud observation), and both single-device and
+sub-device entity grouping.
+
+Look at the git log for `feat/fan-app-parity`. The commits there are
+deliberately grouped so each layer is one commit:
+
+1. normalizer changes + tests
+2. discovery changes + tests
+3. command_handler changes + tests
+4. mitm_proxy wiring (caches + polling + optimistic updates)
+5. addon path sync
+
+Use that as a checklist for your own module.

--- a/docs/sf-protocol.md
+++ b/docs/sf-protocol.md
@@ -1,0 +1,315 @@
+# Spider Farmer GGS Protocol — Reverse-Engineered Notes
+
+What we have learned about the SF cloud ↔ controller protocol while building
+this bridge. Distilled from packet captures, the bundled `schedule-4-real`
+proxy (PyInstaller-decompiled), and lots of trial and error.
+
+This is **not** an official spec. Fields and modeType numbers may vary
+between firmware versions. Treat as a working reference, not a guarantee.
+
+---
+
+## Transport
+
+- The controller talks MQTT-over-TLS to `sf.mqtt.spider-farmer.com:8883`.
+- The Pi proxy intercepts via DNS redirect + iptables NAT to port 8883 on
+  the hotspot interface, terminates TLS, re-establishes upstream TLS to the
+  real cloud, and forwards both directions.
+- The cloud presents a private CA — we ship the SF certs in `certs/` (CA,
+  client cert, client key). mTLS is required upstream; client-side TLS uses
+  our own cert that the controller already trusts (firmware-pinned).
+
+## Topic structure
+
+```
+SF/GGS/{prefix}/API/{UP|DOWN}/{MAC}
+```
+
+- `prefix`: per-controller, learned at runtime. Confirmed values:
+  - `CB` — Control Box
+  - `PS` — Power Strip 5/10
+  - `LC` — Light Controller
+  - More variants likely exist.
+- `UP` — controller → cloud (status, ack, getDevSta responses).
+- `DOWN` — cloud → controller (commands, getDevSta polls).
+- `{MAC}` — device MAC, uppercase, no separators (e.g. `7C2C67F03DAC`).
+
+The proxy learns the prefix the moment the controller subscribes after
+`CONNECT`, so HA outlet/light/fan toggles target the right topic from the
+very first command.
+
+## Methods seen on DOWN (cloud → device)
+
+| Method | Purpose |
+|---|---|
+| `getDevSta` | Cloud asks "what's your current state?". Response on UP carries minimal fields (mOnOff, mLevel, modeType for each module). |
+| `getDevOpLog` | Cloud polls operation log entries, paginated by `id`. |
+| `getSysSta` | System status — firmware version, etc. |
+| `setConfigField` | Write configuration. Carries the full per-module block. |
+| `getConfigField` | Read config — but in our experience the controller does **not** answer proxy-injected `getConfigField`. May be auth-gated to the SF App. |
+
+## `setConfigField` payload shape
+
+```json
+{
+  "method": "setConfigField",
+  "pid": "7C2C67F03DAC",
+  "params": {
+    "keyPath": ["device", "light"],
+    "light": { … full module block … }
+  },
+  "msgId": "1770622729475",
+  "uid": "36656"
+}
+```
+
+- `keyPath` is `[domain, module]`, e.g. `["device", "light"]`,
+  `["device", "fan"]`, `["outlet", "O3"]`.
+- The block under the module key carries every field the controller knows
+  about that module — schedule, mode, current state. Partial updates work
+  for some modules (outlets accept `{modeType, mOnOff}` once the topic
+  prefix is right) but not others (lights need a complete-enough block).
+
+## `msgId` format
+
+Stringified millisecond Unix timestamp (13 digits). Our proxy synthesizes
+the same width when it injects so the controller doesn't reject us based
+on length.
+
+---
+
+## Module: `light` / `light2`
+
+### `modeType`
+
+| Value | App label |
+|---|---|
+| 0 | Manueller Modus |
+| 1 | Zeitfenstermodus |
+| 12 | PPFD |
+
+Higher numbers presumably exist for cycle/sunrise modes — not yet
+confirmed.
+
+### Field map (full setConfigField example)
+
+```json
+"light": {
+  "modeType": 1,
+  "lastAutoModeType": 1,
+  "darkTemp": 0.0,
+  "offTemp": 0.0,
+  "timePeriod": [{
+    "enabled": 1, "weekmask": 127,
+    "startTime": 21600, "endTime": 0,
+    "brightness": 66, "fadeTime": 900
+  }],
+  "ppfdPeriod": [{
+    "enabled": 1, "weekmask": 127,
+    "startTime": 360, "endTime": 0,
+    "brightness": 20, "fadeTime": 180
+  }],
+  "ppfdMinBrightness": 13,
+  "ppfdMaxBrightness": 97,
+  "mOnOff": 1,
+  "mLevel": 65
+}
+```
+
+| Field | Meaning |
+|---|---|
+| `mOnOff` | 0/1 — current on/off state |
+| `mLevel` | 0-100 — current brightness |
+| `modeType` | see table above |
+| `lastAutoModeType` | mirror of modeType (purpose unclear; copy along) |
+| `darkTemp` | °C threshold for dimming. **0.0 = disabled** |
+| `offTemp` | °C threshold for hard-off. **0.0 = disabled** |
+| `timePeriod[]` | Schedule periods for Zeitfenstermodus |
+| `timePeriod[i].startTime` / `endTime` | seconds since midnight, % 86400 |
+| `timePeriod[i].weekmask` | bitfield, bit 0=Mon … bit 6=Sun. 127 = all days |
+| `timePeriod[i].brightness` | target brightness during this period |
+| `timePeriod[i].fadeTime` | sunrise/sunset fade in seconds |
+| `timePeriod[i].enabled` | 0/1 |
+| `ppfdPeriod[]` | Same shape as timePeriod, used in PPFD mode |
+| `ppfdMinBrightness` | floor for PPFD-mode brightness |
+| `ppfdMaxBrightness` | ceiling for PPFD-mode brightness |
+
+### Light Controller (LC) flat schema
+
+The standalone Light Controller reports state as **flat** keys at the top
+level of `data` (i.e. `data.brightness`, `data.mode`) instead of nested
+under `data.light`. Our normalizer handles both.
+
+---
+
+## Module: `fan` / `blower`
+
+### `modeType`
+
+Confirmed by clicking through every dropdown option in the SF App:
+
+| Value | App label |
+|---|---|
+| 0 | Manueller Modus |
+| 1 | Zeitfenstermodus |
+| 2 | Zyklusmodus |
+| 3 | Umweltmodus — Nur Temperatur |
+| 4 | Umweltmodus — Nur Luftfeuchtigkeit |
+| 7 | Umweltmodus — Temperatur priorisieren |
+| 8 | Umweltmodus — Feuchtigkeit priorisieren |
+| 13 | Umweltmodus — Temperatur & Luftfeuchtigkeit |
+
+The "Betriebsmodus" sub-dropdown inside Umweltmodus is **not** a separate
+field — it just maps to one of those modeType numbers. So the fan has
+8 distinct modes total in `modeType`.
+
+### Field map
+
+```json
+"fan": {
+  "modeType": 2,
+  "minSpeed": 1, "maxSpeed": 5,
+  "shakeLevel": 6, "natural": 1,
+  "mOnOff": 1, "mLevel": 3,
+  "timePeriod": [{"enabled": 1, "weekmask": 127, "startTime": 3600, "endTime": 7200}],
+  "cycleTime": {
+    "weekmask": 127,
+    "startTime": 10800,
+    "openDur": 14400,
+    "closeDur": 21600,
+    "times": 2
+  }
+}
+```
+
+| Field | Meaning |
+|---|---|
+| `mOnOff` | Schalter (on/off) |
+| `mLevel` | Gang in Manueller Modus (1-10), reflects current active speed |
+| `maxSpeed` | Gang during scheduled active periods (Zeitfenster / Zyklus). 1-10 |
+| `minSpeed` | Standby-Geschwindigkeit during inactive periods. **0 = Aus** |
+| `shakeLevel` | Oszillation level, 0-10 |
+| `natural` | Natürlicher Wind, 0/1 |
+| `timePeriod[0]` | Zeitfenstermodus schedule (start/end in seconds) |
+| `cycleTime.startTime` | Zyklusmodus: time of day when the cycle starts |
+| `cycleTime.openDur` | Zyklusmodus: run time per cycle, seconds |
+| `cycleTime.closeDur` | Zyklusmodus: off time per cycle, seconds |
+| `cycleTime.times` | Number of executions per day. **Hard-capped at 100** by the controller, regardless of `openDur+closeDur` |
+
+---
+
+## Module: `outlet`
+
+### Block shape
+
+```json
+"outlet": {
+  "psmode": 1,
+  "O1": { "on": 0 },
+  "O2": { "on": 0 },
+  …
+  "O10": { "on": 0 }
+}
+```
+
+`getDevSta` only reports the minimal `{on}` per outlet. `setConfigField`
+carries the full per-outlet block including `cycleTime`, `timePeriod[]`,
+`tempAdd`, `humiAdd`, optional `wateringEnv` and `bind` (sensor binding).
+
+### keyPath for outlet writes
+
+```
+["outlet", "O3"]
+```
+
+### Outlet on/off command
+
+Once the proxy has the right DOWN topic prefix, **a minimal payload is
+enough** to switch an outlet on PS5/PS10:
+
+```json
+{ "modeType": 0, "mOnOff": 1 }
+```
+
+The controller preserves the rest (schedule, watering, sensor binding) on
+its own. This was the breakthrough that made HA outlet control work
+without needing to cache the full block.
+
+### Field map
+
+| Field | Meaning |
+|---|---|
+| `mOnOff` | on/off |
+| `modeType` | 0 = Manuell. Other values follow a schedule/watering automation; we always force 0 on HA toggle |
+| `psmode` | parent-level mode for the whole power strip. Not currently used |
+| `cycleTime.times` | executions per day, used in scheduled outlet automation |
+| `tempAdd` / `humiAdd` | per-outlet temperature / humidity offset for sensor logic |
+| `wateringEnv` | watering automation block for sensor-bound outlets |
+| `bind` | links the outlet to a soil sensor for `wateringEnv` to act on |
+
+---
+
+## Module: `sensors[]` / `sensor`
+
+`data.sensor` carries **average** soil values (when only avg is reported)
+plus the air-side sensors (`temp`, `humi`, `vpd`, `co2`, `ppfd`).
+
+`data.sensors[]` is a list of per-sensor objects, each with:
+
+```json
+{ "id": "3839383705306F29", "tempSoil": 22.5, "humiSoil": 60.0, "ECSoil": 1.2 }
+```
+
+The special id `"avg"` is the average across all soil sensors and is
+already covered by the top-level `data.sensor` block — we skip it during
+per-sensor publishing to avoid duplicates.
+
+---
+
+## Behaviors observed
+
+### DOWN topic prefix
+
+Each controller subscribes to a specific DOWN prefix (`CB`, `PS`, `LC`).
+Sending to the wrong prefix means the controller silently drops the
+command. We learn the prefix from the controller's first SUBSCRIBE.
+
+### Bluetooth bypass
+
+When the SF App is connected to the controller via Bluetooth, settings
+changes go directly over BLE and **bypass the cloud**. To capture
+cloud-side packets you have to disable Bluetooth on the phone first;
+otherwise our proxy never sees the change.
+
+### Partial updates per module
+
+| Module | Accepts partial setConfigField? |
+|---|---|
+| `outlet` | yes (just `{modeType, mOnOff}` is enough) |
+| `light` / `light2` | partial mostly works for direct on/off, but mode changes need `timePeriod` populated |
+| `fan` / `blower` | ditto — mode changes need the relevant block (`timePeriod` for Zeitfenster, `cycleTime` for Zyklus) |
+| `heater` / `humidifier` / `dehumidifier` | minimal `{mOnOff}` works |
+
+### `getConfigField` from proxy
+
+Our proxy-injected `getConfigField` requests **time out** consistently —
+the controller does not respond. The schedule-4-real proxy hits the same
+behavior (its JS catches the timeout silently and falls back to a minimal
+payload).
+
+This is why our HA writes use a **cache** populated from observed cloud
+setConfigField traffic, rather than fetching live state via
+getConfigField. The cache lives in RAM only and gets seeded the first
+time the SF App (with BT off) or the cloud sends a setConfigField for
+that module.
+
+---
+
+## References
+
+- `proxy/normalizer.py` — translates getDevSta into HA state topics
+- `proxy/command_handler.py` — translates HA commands into setConfigField
+- `proxy/mitm_proxy.py` — TLS termination, prefix learning, cache fill
+- `ha/discovery.py` — HA MQTT Discovery configs (entities, sub-devices)
+- `tools/decomp-output/` — local-only reverse-engineered notes from the
+  schedule-4-real binary (gitignored)

--- a/ha/discovery.py
+++ b/ha/discovery.py
@@ -143,7 +143,7 @@ def _light(device_id: str, module: str, name: str, cfg: dict) -> Tuple[str, dict
         "brightness": True,
         "brightness_scale": 100,
         "effect": True,
-        "effect_list": ["Modus: Manual / Timer", "Modus: PPFD"],
+        "effect_list": ["Manual", "Schedule", "PPFD"],
         "availability_topic": f"{base}/availability",
         "device": _device_info(device_id, cfg),
     }
@@ -232,16 +232,15 @@ def _fan_extras(device_id: str, module: str, friendly: str, cfg: dict) -> list:
                      "Off Time", 0, 1440, 1, cfg, unit="min", device=cycle_dev),
         _number_path(device_id, module, "cycle_times",
                      "Cycles", 1, 100, 1, cfg, device=cycle_dev),
-        # Speeds
+        # Speeds (catch-all fan settings — applies across all modes)
         _number_path(device_id, module, "schedule_speed",
                      "Speed", 1, 10, 1, cfg, device=speeds_dev),
         _number_path(device_id, module, "standby_speed",
                      "Standby Speed", 0, 10, 1, cfg, device=speeds_dev),
         _number_path(device_id, module, "oscillation_level",
                      "Oscillation", 0, 10, 1, cfg, device=speeds_dev),
-        # Natural wind sits on the main device.
         _switch_path(device_id, module, "natural_wind",
-                     f"{friendly} Natural Wind", cfg),
+                     "Natural Wind", cfg, device=speeds_dev),
     ]
 
 

--- a/ha/discovery.py
+++ b/ha/discovery.py
@@ -64,6 +64,73 @@ def _switch(device_id: str, field: str, name: str, cfg: dict) -> Tuple[str, dict
     return f"homeassistant/switch/{uid}/config", payload
 
 
+def _number_path(device_id: str, path: str, suffix: str, name: str,
+                 min_val, max_val, step, cfg: dict, unit: str | None = None,
+                 device: dict | None = None) -> Tuple[str, dict]:
+    uid = f"spiderfarmer_{device_id}_{path}_{suffix}"
+    payload = {
+        "name": name,
+        "unique_id": uid,
+        "state_topic": f"spiderfarmer/{device_id}/state/{path}/{suffix}",
+        "command_topic": f"spiderfarmer/{device_id}/command/{path}/{suffix}/set",
+        "availability_topic": f"spiderfarmer/{device_id}/availability",
+        "min": min_val,
+        "max": max_val,
+        "step": step,
+        "entity_category": "config",
+        "device": device or _device_info(device_id, cfg),
+    }
+    if unit:
+        payload["unit_of_measurement"] = unit
+    return f"homeassistant/number/{uid}/config", payload
+
+
+def _text_path(device_id: str, path: str, suffix: str, name: str, pattern: str,
+               cfg: dict, device: dict | None = None) -> Tuple[str, dict]:
+    uid = f"spiderfarmer_{device_id}_{path}_{suffix}"
+    payload = {
+        "name": name,
+        "unique_id": uid,
+        "state_topic": f"spiderfarmer/{device_id}/state/{path}/{suffix}",
+        "command_topic": f"spiderfarmer/{device_id}/command/{path}/{suffix}/set",
+        "availability_topic": f"spiderfarmer/{device_id}/availability",
+        "pattern": pattern,
+        "entity_category": "config",
+        "device": device or _device_info(device_id, cfg),
+    }
+    return f"homeassistant/text/{uid}/config", payload
+
+
+def _switch_path(device_id: str, path: str, suffix: str, name: str, cfg: dict,
+                 device: dict | None = None) -> Tuple[str, dict]:
+    uid = f"spiderfarmer_{device_id}_{path}_{suffix}"
+    payload = {
+        "name": name,
+        "unique_id": uid,
+        "state_topic": f"spiderfarmer/{device_id}/state/{path}/{suffix}",
+        "command_topic": f"spiderfarmer/{device_id}/command/{path}/{suffix}/set",
+        "availability_topic": f"spiderfarmer/{device_id}/availability",
+        "payload_on": "ON",
+        "payload_off": "OFF",
+        "device": device or _device_info(device_id, cfg),
+    }
+    return f"homeassistant/switch/{uid}/config", payload
+
+
+def _settings_subdevice(parent_id: str, parent_name: str, slug: str,
+                        suffix_name: str, model: str) -> dict:
+    """HA MQTT device-info for a settings sub-device, linked to the main
+    controller via via_device so HA renders it as a separate card on the
+    parent's device page."""
+    return {
+        "identifiers": [f"{parent_id}_{slug}"],
+        "name": f"{parent_name} {suffix_name}",
+        "manufacturer": "Spider Farmer",
+        "model": model,
+        "via_device": parent_id,
+    }
+
+
 def _light(device_id: str, module: str, name: str, cfg: dict) -> Tuple[str, dict]:
     uid = f"spiderfarmer_{device_id}_{module}"
     base = f"spiderfarmer/{device_id}"
@@ -83,8 +150,20 @@ def _light(device_id: str, module: str, name: str, cfg: dict) -> Tuple[str, dict
     return f"homeassistant/light/{uid}/config", payload
 
 
+_FAN_PRESET_MODES = [
+    "Manual",
+    "Schedule",
+    "Cycle",
+    "Environment: Prioritize temperature",
+    "Environment: Prioritize humidity",
+    "Environment: Temperature only",
+    "Environment: Humidity only",
+    "Environment: Temperature & humidity",
+]
+
+
 def _fan(device_id: str, module: str, name: str, speed_max: int, cfg: dict,
-         oscillation: bool = False) -> Tuple[str, dict]:
+         oscillation: bool = False, preset_modes: bool = False) -> Tuple[str, dict]:
     uid = f"spiderfarmer_{device_id}_{module}"
     base = f"spiderfarmer/{device_id}"
     payload = {
@@ -111,7 +190,59 @@ def _fan(device_id: str, module: str, name: str, speed_max: int, cfg: dict,
             "payload_oscillation_on": "oscillate_on",
             "payload_oscillation_off": "oscillate_off",
         })
+    if preset_modes:
+        # Mirror the SF App's Modus dropdown — 8 modes including 5 Umwelt
+        # variants. Selection routes back via /command/{module}/preset_mode/set
+        # and resolves to the matching modeType in command_handler.
+        payload.update({
+            "preset_mode_state_topic": f"{base}/state/{module}/mode_label",
+            "preset_mode_command_topic": f"{base}/command/{module}/preset_mode/set",
+            "preset_modes": list(_FAN_PRESET_MODES),
+        })
     return f"homeassistant/fan/{uid}/config", payload
+
+
+def _fan_extras(device_id: str, module: str, friendly: str, cfg: dict) -> list:
+    """Sub-device entities mirroring the SF App's Lüfter-Einstellungen screen
+    for one fan/blower. Three sub-devices linked via via_device:
+      - Zeitfenstermodus: schedule_start, schedule_end
+      - Zyklusmodus: cycle_start, cycle_run, cycle_off, cycle_times
+      - Geschwindigkeiten: schedule_speed, standby_speed, oscillation_level
+    Plus a switch on the main device for natural_wind."""
+    parent_id = f"spiderfarmer_{device_id}"
+    sched_dev = _settings_subdevice(parent_id, friendly, f"{module}_schedule",
+                                    "Schedule Mode", "Schedule settings")
+    cycle_dev = _settings_subdevice(parent_id, friendly, f"{module}_cycle",
+                                    "Cycle Mode", "Cycle settings")
+    speeds_dev = _settings_subdevice(parent_id, friendly, f"{module}_speeds",
+                                     "Speeds", "Speed settings")
+    HHMM = r"^([01]\d|2[0-3]):[0-5]\d$"
+    return [
+        # Schedule Mode
+        _text_path(device_id, module, "schedule_start",
+                   "Start Time", HHMM, cfg, device=sched_dev),
+        _text_path(device_id, module, "schedule_end",
+                   "End Time", HHMM, cfg, device=sched_dev),
+        # Cycle Mode
+        _text_path(device_id, module, "cycle_start",
+                   "Start Time", HHMM, cfg, device=cycle_dev),
+        _number_path(device_id, module, "cycle_run_minutes",
+                     "Run Time", 0, 1440, 1, cfg, unit="min", device=cycle_dev),
+        _number_path(device_id, module, "cycle_off_minutes",
+                     "Off Time", 0, 1440, 1, cfg, unit="min", device=cycle_dev),
+        _number_path(device_id, module, "cycle_times",
+                     "Cycles", 1, 100, 1, cfg, device=cycle_dev),
+        # Speeds
+        _number_path(device_id, module, "schedule_speed",
+                     "Speed", 1, 10, 1, cfg, device=speeds_dev),
+        _number_path(device_id, module, "standby_speed",
+                     "Standby Speed", 0, 10, 1, cfg, device=speeds_dev),
+        _number_path(device_id, module, "oscillation_level",
+                     "Oscillation", 0, 10, 1, cfg, device=speeds_dev),
+        # Natural wind sits on the main device.
+        _switch_path(device_id, module, "natural_wind",
+                     f"{friendly} Natural Wind", cfg),
+    ]
 
 
 def publish_discovery_for_device(
@@ -136,8 +267,14 @@ def publish_discovery_for_device(
     entities.append(_light(device_id, "light2", "Light 2", device_cfg))
 
     # ── Fans ──────────────────────────────────────────────────────────────────
-    entities.append(_fan(device_id, "blower", "Fan Exhaust",     100, device_cfg))
-    entities.append(_fan(device_id, "fan", "Fan Circulation", 10, device_cfg))
+    entities.append(_fan(device_id, "blower", "Fan Exhaust", 100, device_cfg))
+    # Fan Circulation gets the new app-parity entities: preset_modes on the
+    # main fan plus three sub-devices (Schedule Mode, Cycle Mode, Speeds)
+    # and a switch for natural wind. Fan Exhaust (blower) is intentionally
+    # left as the simple variant for now — same pattern, follow-up.
+    entities.append(_fan(device_id, "fan", "Fan Circulation", 10, device_cfg,
+                         preset_modes=True))
+    entities += _fan_extras(device_id, "fan", "Fan", device_cfg)
 
     # ── Soil sensors (average) ────────────────────────────────────────────────
     entities += [

--- a/ha/discovery.py
+++ b/ha/discovery.py
@@ -117,6 +117,32 @@ def _switch_path(device_id: str, path: str, suffix: str, name: str, cfg: dict,
     return f"homeassistant/switch/{uid}/config", payload
 
 
+def _number_path_aliased(device_id: str, path: str, suffix: str, alias: str,
+                         name: str, min_val, max_val, step, cfg: dict,
+                         unit: str | None = None,
+                         device: dict | None = None) -> Tuple[str, dict]:
+    """Like _number_path but lets the unique_id diverge from the topic. Used
+    to expose the same temperature-protection fields under two sub-devices
+    (Schedule and PPFD) — both control the same controller field, so the
+    state and command topics match, but HA needs distinct unique_ids."""
+    uid = f"spiderfarmer_{device_id}_{path}_{suffix}_{alias}"
+    payload = {
+        "name": name,
+        "unique_id": uid,
+        "state_topic": f"spiderfarmer/{device_id}/state/{path}/{suffix}",
+        "command_topic": f"spiderfarmer/{device_id}/command/{path}/{suffix}/set",
+        "availability_topic": f"spiderfarmer/{device_id}/availability",
+        "min": min_val,
+        "max": max_val,
+        "step": step,
+        "entity_category": "config",
+        "device": device or _device_info(device_id, cfg),
+    }
+    if unit:
+        payload["unit_of_measurement"] = unit
+    return f"homeassistant/number/{uid}/config", payload
+
+
 def _settings_subdevice(parent_id: str, parent_name: str, slug: str,
                         suffix_name: str, model: str) -> dict:
     """HA MQTT device-info for a settings sub-device, linked to the main
@@ -202,6 +228,65 @@ def _fan(device_id: str, module: str, name: str, speed_max: int, cfg: dict,
     return f"homeassistant/fan/{uid}/config", payload
 
 
+def _light_extras(device_id: str, module: str, friendly: str, cfg: dict) -> list:
+    """Sub-device entities mirroring the SF App's "Lampe Einstellungen" screen
+    for one light. Two sub-devices linked via via_device:
+      - Schedule Mode: schedule_brightness, schedule_start/end, fade_minutes,
+        plus the Temperaturschutz fields (dim/off thresholds).
+      - PPFD Mode: ppfd_target/min/max/start/end/fade_minutes, plus the same
+        Temperaturschutz fields (per user request — Temperaturschutz applies
+        in both modes, so it is exposed in both groups rather than a
+        separate settings card).
+    Note: dim_threshold/off_threshold appear under each sub-device with
+    distinct unique_ids but identical state/command topics, so HA shows
+    them in both cards while a single change keeps them synchronized."""
+    parent_id = f"spiderfarmer_{device_id}"
+    sched_dev = _settings_subdevice(parent_id, friendly, f"{module}_schedule",
+                                    "Schedule Mode", "Schedule settings")
+    ppfd_dev = _settings_subdevice(parent_id, friendly, f"{module}_ppfd",
+                                   "PPFD Mode", "PPFD settings")
+    HHMM = r"^([01]\d|2[0-3]):[0-5]\d$"
+    return [
+        # Schedule Mode
+        _number_path(device_id, module, "schedule_brightness",
+                     "Brightness", 0, 100, 1, cfg, unit="%", device=sched_dev),
+        _text_path(device_id, module, "schedule_start",
+                   "Start Time", HHMM, cfg, device=sched_dev),
+        _text_path(device_id, module, "schedule_end",
+                   "End Time", HHMM, cfg, device=sched_dev),
+        _number_path(device_id, module, "fade_minutes",
+                     "Fade Time", 0, 240, 1, cfg, unit="min", device=sched_dev),
+        # Temperaturschutz under Schedule
+        _number_path_aliased(device_id, module, "dim_threshold", "schedule",
+                             "Dim Threshold", 0, 50, 0.1, cfg,
+                             unit="°C", device=sched_dev),
+        _number_path_aliased(device_id, module, "off_threshold", "schedule",
+                             "Off Threshold", 0, 50, 0.1, cfg,
+                             unit="°C", device=sched_dev),
+        # PPFD Mode
+        _number_path(device_id, module, "ppfd_target",
+                     "Target PPFD", 0, 1000, 1, cfg,
+                     unit="µmol/m²/s", device=ppfd_dev),
+        _number_path(device_id, module, "ppfd_min",
+                     "Min Brightness", 0, 100, 1, cfg, unit="%", device=ppfd_dev),
+        _number_path(device_id, module, "ppfd_max",
+                     "Max Brightness", 0, 100, 1, cfg, unit="%", device=ppfd_dev),
+        _text_path(device_id, module, "ppfd_start",
+                   "Start Time", HHMM, cfg, device=ppfd_dev),
+        _text_path(device_id, module, "ppfd_end",
+                   "End Time", HHMM, cfg, device=ppfd_dev),
+        _number_path(device_id, module, "ppfd_fade_minutes",
+                     "Fade Time", 0, 240, 1, cfg, unit="min", device=ppfd_dev),
+        # Temperaturschutz under PPFD (same topics, distinct unique_id)
+        _number_path_aliased(device_id, module, "dim_threshold", "ppfd",
+                             "Dim Threshold", 0, 50, 0.1, cfg,
+                             unit="°C", device=ppfd_dev),
+        _number_path_aliased(device_id, module, "off_threshold", "ppfd",
+                             "Off Threshold", 0, 50, 0.1, cfg,
+                             unit="°C", device=ppfd_dev),
+    ]
+
+
 def _fan_extras(device_id: str, module: str, friendly: str, cfg: dict) -> list:
     """Sub-device entities mirroring the SF App's Lüfter-Einstellungen screen
     for one fan/blower. Three sub-devices linked via via_device:
@@ -262,7 +347,11 @@ def publish_discovery_for_device(
     ]
 
     # ── Light ─────────────────────────────────────────────────────────────────
+    # Light 1 gets the new app-parity entities (Schedule Mode + PPFD Mode
+    # sub-devices). Light 2 stays as the simple variant — only Light 1 was
+    # exposed via the SF App's settings screen the user mirrored.
     entities.append(_light(device_id, "light",  "Light 1", device_cfg))
+    entities += _light_extras(device_id, "light", "Light 1", device_cfg)
     entities.append(_light(device_id, "light2", "Light 2", device_cfg))
 
     # ── Fans ──────────────────────────────────────────────────────────────────

--- a/main_proxy.py
+++ b/main_proxy.py
@@ -52,9 +52,19 @@ def main() -> None:
         loop.add_signal_handler(signal.SIGTERM, stop.set)
         loop.add_signal_handler(signal.SIGINT, stop.set)
 
+        # Background task: periodically pull fresh config from active
+        # controllers so HA entities stay in sync with App-side changes
+        # the user makes without having to interact with HA.
+        poll_task = asyncio.create_task(proxy.config_poll_loop())
+
         logger.info("Proxy listening on %s:%s", pcfg["listen_host"], pcfg["listen_port"])
         async with server:
             await stop.wait()
+        poll_task.cancel()
+        try:
+            await poll_task
+        except asyncio.CancelledError:
+            pass
         logger.info("Shutting down")
 
     try:

--- a/proxy/command_handler.py
+++ b/proxy/command_handler.py
@@ -154,10 +154,16 @@ def translate_command(
                 tp.append({})
             tp[0]["endTime"] = _hhmm_to_seconds(value)
         elif subfield == "schedule_speed":
+            # The controller uses different fields for the active speed
+            # depending on mode: mLevel in Manual, maxSpeed in
+            # Schedule/Cycle/Environment. Write both so a single HA "Speed"
+            # entity actually changes the fan regardless of current mode.
             try:
-                block["maxSpeed"] = max(1, min(10, int(float(value))))
+                v = max(1, min(10, int(float(value))))
             except (ValueError, TypeError):
                 return None
+            block["maxSpeed"] = v
+            block["mLevel"] = v
         elif subfield == "standby_speed":
             try:
                 block["minSpeed"] = max(0, min(10, int(float(value))))

--- a/proxy/command_handler.py
+++ b/proxy/command_handler.py
@@ -7,9 +7,34 @@ logger = logging.getLogger(__name__)
 
 _TIME_PERIOD = [{"weekmask": 127}]
 
+# Reverse mapping of the fan modeType labels surfaced as preset_modes in HA.
+# Order here matches the SF App dropdown so the HA UI lists modes in the
+# same order the user sees in the App.
+_FAN_MODE_TO_TYPE = {
+    "Manual": 0,
+    "Schedule": 1,
+    "Cycle": 2,
+    "Environment: Prioritize temperature": 7,
+    "Environment: Prioritize humidity": 8,
+    "Environment: Temperature only": 3,
+    "Environment: Humidity only": 4,
+    "Environment: Temperature & humidity": 13,
+}
+
 
 def _onoff(v) -> int:
     return 1 if str(v).upper() in ("ON", "1", "TRUE") else 0
+
+
+def _hhmm_to_seconds(s) -> int:
+    """Parse 'HH:MM' to seconds since midnight; 0 on parse error."""
+    try:
+        parts = str(s).split(":")
+        h = int(parts[0])
+        m = int(parts[1]) if len(parts) > 1 else 0
+        return (h * 3600 + m * 60) % 86400
+    except (ValueError, IndexError):
+        return 0
 
 
 def _build(mac: str, uid: str, domain: str, module: str, obj: dict) -> dict:
@@ -31,9 +56,11 @@ def translate_command(
     device_state: Optional[dict] = None,
     subfield: Optional[str] = None,
     last_nonzero_level: Optional[dict] = None,
+    fan_state: Optional[dict] = None,
 ) -> Optional[dict]:
     state = device_state or {}
     last_levels = last_nonzero_level or {}
+    fans = fan_state or {}
 
     # ── Outlet ────────────────────────────────────────────────────────────────
     # Minimal payload — the controller already has the schedule/watering
@@ -74,6 +101,98 @@ def translate_command(
             "mLevel": level,
             "timePeriod": cur.get("timePeriod", _TIME_PERIOD),
         })
+
+    # ── Fan / Blower — app-parity subfield writes ───────────────────────────
+    # New HA entities (preset_mode, schedule_*, cycle_*, schedule_speed,
+    # standby_speed, oscillation_level, natural_wind) each map to one field
+    # on the controller's fan/blower block. Merge the subfield into a copy
+    # of the cached block so the rest of the controller's settings stay
+    # intact. When the cache is empty, synthesize a sensible default block
+    # so the controller does not silently reject the partial command.
+    _FAN_SUBFIELDS = {
+        "preset_mode", "schedule_start", "schedule_end",
+        "schedule_speed", "standby_speed",
+        "cycle_start", "cycle_run_minutes", "cycle_off_minutes", "cycle_times",
+        "oscillation_level", "natural_wind",
+    }
+    if field in ("fan", "blower") and subfield in _FAN_SUBFIELDS:
+        cached = fans.get(field)
+        if cached:
+            block = dict(cached)
+        else:
+            cur = state.get(field, {})
+            block = {
+                "modeType": cur.get("modeType", 0),
+                "mOnOff": int(cur.get("on", cur.get("mOnOff", 0))),
+                "mLevel": int(cur.get("level", cur.get("mLevel", 1))),
+                "shakeLevel": int(cur.get("shakeLevel", 0)),
+                "natural": 0,
+                "minSpeed": 0,
+                "maxSpeed": 1,
+                "timePeriod": [{"enabled": 1, "weekmask": 127, "startTime": 0, "endTime": 0}],
+                "cycleTime": {"weekmask": 127, "startTime": 0, "openDur": 0, "closeDur": 0, "times": 1},
+            }
+            logger.info(
+                "[%s] Fan cache empty — using synthesized defaults for %s/%s",
+                field, field, subfield,
+            )
+
+        if subfield == "preset_mode":
+            mt = _FAN_MODE_TO_TYPE.get(value)
+            if mt is None:
+                logger.warning("Unknown fan preset_mode: %s", value)
+                return None
+            block["modeType"] = mt
+        elif subfield == "schedule_start":
+            tp = block.setdefault("timePeriod", [{}])
+            if not tp:
+                tp.append({})
+            tp[0]["startTime"] = _hhmm_to_seconds(value)
+        elif subfield == "schedule_end":
+            tp = block.setdefault("timePeriod", [{}])
+            if not tp:
+                tp.append({})
+            tp[0]["endTime"] = _hhmm_to_seconds(value)
+        elif subfield == "schedule_speed":
+            try:
+                block["maxSpeed"] = max(1, min(10, int(float(value))))
+            except (ValueError, TypeError):
+                return None
+        elif subfield == "standby_speed":
+            try:
+                block["minSpeed"] = max(0, min(10, int(float(value))))
+            except (ValueError, TypeError):
+                return None
+        elif subfield == "cycle_start":
+            ct = block.setdefault("cycleTime", {"weekmask": 127})
+            ct["startTime"] = _hhmm_to_seconds(value)
+        elif subfield == "cycle_run_minutes":
+            ct = block.setdefault("cycleTime", {"weekmask": 127})
+            try:
+                ct["openDur"] = max(0, int(float(value))) * 60
+            except (ValueError, TypeError):
+                return None
+        elif subfield == "cycle_off_minutes":
+            ct = block.setdefault("cycleTime", {"weekmask": 127})
+            try:
+                ct["closeDur"] = max(0, int(float(value))) * 60
+            except (ValueError, TypeError):
+                return None
+        elif subfield == "cycle_times":
+            ct = block.setdefault("cycleTime", {"weekmask": 127})
+            try:
+                # Controller hard-caps at 100 regardless of cycle duration.
+                ct["times"] = max(1, min(100, int(float(value))))
+            except (ValueError, TypeError):
+                return None
+        elif subfield == "oscillation_level":
+            try:
+                block["shakeLevel"] = max(0, min(10, int(float(value))))
+            except (ValueError, TypeError):
+                return None
+        elif subfield == "natural_wind":
+            block["natural"] = _onoff(value)
+        return _build(mac, uid, "device", field, block)
 
     # ── Blower on/off ─────────────────────────────────────────────────────────
     if field == "blower" and subfield is None:

--- a/proxy/command_handler.py
+++ b/proxy/command_handler.py
@@ -57,10 +57,12 @@ def translate_command(
     subfield: Optional[str] = None,
     last_nonzero_level: Optional[dict] = None,
     fan_state: Optional[dict] = None,
+    light_state: Optional[dict] = None,
 ) -> Optional[dict]:
     state = device_state or {}
     last_levels = last_nonzero_level or {}
     fans = fan_state or {}
+    lights = light_state or {}
 
     # ── Outlet ────────────────────────────────────────────────────────────────
     # Minimal payload — the controller already has the schedule/watering
@@ -70,6 +72,108 @@ def translate_command(
     if outlet_num is not None:
         ok = f"O{outlet_num}"
         return _build(mac, uid, "outlet", ok, {"modeType": 0, "mOnOff": _onoff(value)})
+
+    # ── Light / Light2 — app-parity subfield writes ─────────────────────────
+    # Mirror the SF App's "Lampe Einstellungen" screen. Each HA entity (text/
+    # number/switch under /command/light/<subfield>/set) maps to one field on
+    # the controller's light/light2 block. Merge the subfield into a copy of
+    # the cached block so the rest of the lamp's settings stay intact. When
+    # the cache is empty, synthesize a default block so the controller does
+    # not silently reject the partial command.
+    _LIGHT_SUBFIELDS = {
+        "dim_threshold", "off_threshold",
+        "schedule_brightness", "schedule_start", "schedule_end", "fade_minutes",
+        "ppfd_target", "ppfd_start", "ppfd_end", "ppfd_fade_minutes",
+        "ppfd_min", "ppfd_max",
+    }
+    if field in ("light", "light2") and subfield in _LIGHT_SUBFIELDS:
+        cached = lights.get(field)
+        if cached:
+            block = dict(cached)
+        else:
+            cur = state.get(field, {})
+            block = {
+                "modeType": cur.get("modeType", 0),
+                "lastAutoModeType": cur.get("lastAutoModeType", 0),
+                "mOnOff": int(cur.get("on", cur.get("mOnOff", 0))),
+                "mLevel": int(cur.get("level", cur.get("mLevel", 0))),
+                "darkTemp": 0,
+                "offTemp": 0,
+                "timePeriod": [{"enabled": 1, "weekmask": 127,
+                                "startTime": 0, "endTime": 0,
+                                "brightness": 0, "fadeTime": 0}],
+                "ppfdPeriod": [{"enabled": 0, "weekmask": 127,
+                                "startTime": 0, "endTime": 0,
+                                "brightness": 0, "fadeTime": 0}],
+                "ppfdMinBrightness": 0,
+                "ppfdMaxBrightness": 100,
+            }
+            logger.info(
+                "Light cache empty — using synthesized defaults for %s/%s",
+                field, subfield,
+            )
+
+        def _tp0():
+            tp = block.setdefault("timePeriod", [{}])
+            if not tp:
+                tp.append({})
+            return tp[0]
+
+        def _pp0():
+            pp = block.setdefault("ppfdPeriod", [{}])
+            if not pp:
+                pp.append({})
+            return pp[0]
+
+        if subfield == "dim_threshold":
+            try:
+                block["darkTemp"] = float(value)
+            except (ValueError, TypeError):
+                return None
+        elif subfield == "off_threshold":
+            try:
+                block["offTemp"] = float(value)
+            except (ValueError, TypeError):
+                return None
+        elif subfield == "schedule_brightness":
+            try:
+                _tp0()["brightness"] = max(0, min(100, int(float(value))))
+            except (ValueError, TypeError):
+                return None
+        elif subfield == "schedule_start":
+            _tp0()["startTime"] = _hhmm_to_seconds(value)
+        elif subfield == "schedule_end":
+            _tp0()["endTime"] = _hhmm_to_seconds(value)
+        elif subfield == "fade_minutes":
+            try:
+                _tp0()["fadeTime"] = max(0, int(float(value))) * 60
+            except (ValueError, TypeError):
+                return None
+        elif subfield == "ppfd_target":
+            try:
+                _pp0()["brightness"] = max(0, min(1000, int(float(value))))
+            except (ValueError, TypeError):
+                return None
+        elif subfield == "ppfd_start":
+            _pp0()["startTime"] = _hhmm_to_seconds(value)
+        elif subfield == "ppfd_end":
+            _pp0()["endTime"] = _hhmm_to_seconds(value)
+        elif subfield == "ppfd_fade_minutes":
+            try:
+                _pp0()["fadeTime"] = max(0, int(float(value))) * 60
+            except (ValueError, TypeError):
+                return None
+        elif subfield == "ppfd_min":
+            try:
+                block["ppfdMinBrightness"] = max(0, min(100, int(float(value))))
+            except (ValueError, TypeError):
+                return None
+        elif subfield == "ppfd_max":
+            try:
+                block["ppfdMaxBrightness"] = max(0, min(100, int(float(value))))
+            except (ValueError, TypeError):
+                return None
+        return _build(mac, uid, "device", field, block)
 
     # ── Light / Light2 ────────────────────────────────────────────────────────
     # The SF cloud always sends modeType=0 (Manual) for direct app control —

--- a/proxy/command_handler.py
+++ b/proxy/command_handler.py
@@ -76,7 +76,14 @@ def translate_command(
     # mode 1 (Timer) makes the controller follow the stored schedule and
     # ignore mOnOff/mLevel. Mirror the cloud's payload shape so HA actually
     # controls the lamp instead of fighting the schedule.
-    _EFFECT_TO_MODE = {"Modus: Manual / Timer": 0, "Modus: PPFD": 12}
+    # Mode label ↔ modeType, confirmed against SF App. Old "Manual / Timer"
+    # alias kept so HA selects from previous installs still resolve.
+    _EFFECT_TO_MODE = {
+        "Manual": 0,
+        "Schedule": 1,
+        "PPFD": 12,
+        "Modus: Manual / Timer": 0,
+    }
     if field in ("light", "light2"):
         cur = state.get(field, {})
         try:

--- a/proxy/mitm_proxy.py
+++ b/proxy/mitm_proxy.py
@@ -12,7 +12,7 @@ from .mqtt_parser import (
     parse_packets, build_publish,
     MQTT_PUBLISH, MQTT_CONNECT, MQTT_SUBSCRIBE,
 )
-from .normalizer import normalize_status, fan_extras_topics
+from .normalizer import normalize_status, fan_extras_topics, light_extras_topics
 from ha.discovery import (
     publish_soil_sensor_discovery as _publish_soil_sensor_discovery,
     unpublish_outlet_discovery as _unpublish_outlet_discovery,
@@ -229,7 +229,8 @@ class MITMProxy:
         payload = translate_command(field, value, session.mac, session.uid, outlet_num,
                                     device_state=session.device_state, subfield=subfield,
                                     last_nonzero_level=session.last_nonzero_level,
-                                    fan_state=session.fan_state)
+                                    fan_state=session.fan_state,
+                                    light_state=session.light_state)
         if payload:
             await session.inject(payload)
             # Optimistic update: write the fan/blower fields to the cache and
@@ -441,6 +442,13 @@ class MITMProxy:
                                             for k in ("light", "light2"):
                                                 if k in keypath and isinstance(params.get(k), dict):
                                                     sess.light_state[k] = params[k]
+                                                    # Also push the per-field
+                                                    # extras so HA settings
+                                                    # entities populate even
+                                                    # without a getDevSta echo.
+                                                    for tpc, val in light_extras_topics(
+                                                            sess.device_id, k, params[k]).items():
+                                                        self.mqtt_client.publish(tpc, val, retain=True)
                         except Exception as e:
                             # Never let logging break the relay
                             logger.debug("relay_down parse error (non-fatal): %s", e)

--- a/proxy/mitm_proxy.py
+++ b/proxy/mitm_proxy.py
@@ -54,6 +54,12 @@ class ProxySession:
         # setConfigField traffic carries the schedule/cycle/speeds we
         # need to merge against on HA writes.
         self.fan_state: Dict[str, dict] = {}
+        # Same idea for light: getDevSta on some firmwares omits
+        # modeType, so we cache it from observed setConfigField traffic
+        # and from our own injects. Used by the normalizer as a fallback
+        # so the HA effect dropdown stays consistent with what the
+        # controller is actually doing.
+        self.light_state: Dict[str, dict] = {}
 
     def set_upstream(self, writer: asyncio.StreamWriter) -> None:
         self._upstream_writer = writer
@@ -190,6 +196,20 @@ class MITMProxy:
                 if isinstance(blk, dict):
                     session.fan_state[k] = blk
                     for tpc, val in fan_extras_topics(session.device_id, k, blk).items():
+                        self.mqtt_client.publish(tpc, val, retain=True)
+            # Same for light — and refresh the main state/light JSON so
+            # the HA effect dropdown reflects the new mode immediately
+            # rather than waiting for the next getDevSta (which on some
+            # firmwares does not even carry modeType).
+            for k in ("light", "light2"):
+                blk = params.get(k)
+                if isinstance(blk, dict):
+                    session.light_state[k] = blk
+                    refreshed = normalize_status(
+                        session.device_id, {"data": {k: blk}},
+                        light_cache=session.light_state,
+                    )
+                    for tpc, val in refreshed.items():
                         self.mqtt_client.publish(tpc, val, retain=True)
 
     async def handle_client(
@@ -361,6 +381,12 @@ class MITMProxy:
                                                     for tpc, val in fan_extras_topics(
                                                             sess.device_id, k, params[k]).items():
                                                         self.mqtt_client.publish(tpc, val, retain=True)
+                                    if "light" in keypath or "light2" in keypath:
+                                        sess = nonlocal_session[0]
+                                        if sess is not None:
+                                            for k in ("light", "light2"):
+                                                if k in keypath and isinstance(params.get(k), dict):
+                                                    sess.light_state[k] = params[k]
                         except Exception as e:
                             # Never let logging break the relay
                             logger.debug("relay_down parse error (non-fatal): %s", e)
@@ -469,7 +495,11 @@ def _process_publish(session: ProxySession, pkt, mqtt_client: mqtt.Client,
                             session.device_id, sorted(present))
                 session._outlet_discovery_pruned = True
 
-    normalized = normalize_status(session.device_id, data)
+    normalized = normalize_status(
+        session.device_id, data,
+        light_cache=getattr(session, "light_state", None),
+        fan_cache=getattr(session, "fan_state", None),
+    )
     for norm_topic, value in normalized.items():
         mqtt_client.publish(norm_topic, value, retain=True)
 

--- a/proxy/mitm_proxy.py
+++ b/proxy/mitm_proxy.py
@@ -163,13 +163,30 @@ class MITMProxy:
         except Exception as e:
             logger.error("Fehler beim Speichern von config.yaml: %s", e)
 
+    async def poll_session_config(self, sess: ProxySession) -> None:
+        """Inject one round of getConfigField for light/light2/fan/blower
+        into a single session. Called on session connect (immediate poll)
+        and periodically by config_poll_loop."""
+        for keypath in (["device", "light"], ["device", "light2"],
+                        ["device", "fan"], ["device", "blower"]):
+            try:
+                await sess.inject({
+                    "method": "getConfigField",
+                    "pid": sess.mac,
+                    "params": {"keyPath": keypath},
+                    "msgId": str(int(time.time() * 1000)),
+                    "uid": sess.uid,
+                })
+            except Exception as e:
+                logger.debug("config poll inject failed for %s: %s",
+                             keypath, e)
+            # Space out so we don't flood the controller in one burst
+            await asyncio.sleep(0.5)
+
     async def config_poll_loop(self) -> None:
-        """Periodically inject getConfigField requests for light/light2/fan/
-        blower into every active controller session. If the controller
-        honors them, the responses come back through relay_up, get parsed
-        by _process_publish, and refresh the light_state / fan_state caches
-        without any user interaction. If the controller ignores them
-        (firmware-dependent), this is harmless.
+        """Periodically poll every active controller session. Each session
+        also gets an immediate one-shot poll on connect (handle_client),
+        so this loop only owns the recurring tick.
 
         Interval is configurable via proxy.config_poll_interval_sec
         (default 600 = 10 minutes). Set to 0 to disable."""
@@ -178,28 +195,11 @@ class MITMProxy:
             logger.info("Config poll disabled (interval=%s)", interval)
             return
         logger.info("Config poll loop started, interval=%ds", interval)
-        # Initial delay so the first poll happens after sessions have had
-        # time to establish. Otherwise we'd inject into nothing.
-        await asyncio.sleep(min(60, interval))
         while True:
             try:
-                for sess in list(self._sessions.values()):
-                    for keypath in (["device", "light"], ["device", "light2"],
-                                    ["device", "fan"], ["device", "blower"]):
-                        try:
-                            await sess.inject({
-                                "method": "getConfigField",
-                                "pid": sess.mac,
-                                "params": {"keyPath": keypath},
-                                "msgId": str(int(time.time() * 1000)),
-                                "uid": sess.uid,
-                            })
-                        except Exception as e:
-                            logger.debug("config poll inject failed for %s: %s",
-                                         keypath, e)
-                        # Space out so we don't flood the controller in one burst
-                        await asyncio.sleep(0.5)
                 await asyncio.sleep(interval)
+                for sess in list(self._sessions.values()):
+                    await self.poll_session_config(sess)
             except asyncio.CancelledError:
                 logger.info("Config poll loop stopped")
                 break
@@ -293,6 +293,15 @@ class MITMProxy:
                 self._sessions[s.device_id] = s
                 s.publish_availability("online")
                 logger.info("Session erstellt: device_id=%s mac=%s", s.device_id, s.mac)
+                # Immediate one-shot config poll so HA caches refresh on
+                # restart/reconnect rather than waiting for the next 10-min
+                # tick. Detached so the connect path doesn't block on it.
+                async def _initial_poll():
+                    # Small delay so the controller has finished its CONNECT
+                    # handshake before we start firing extra requests at it.
+                    await asyncio.sleep(3)
+                    await self.poll_session_config(s)
+                asyncio.create_task(_initial_poll())
                 return s
 
             async def relay_up():

--- a/proxy/mitm_proxy.py
+++ b/proxy/mitm_proxy.py
@@ -326,6 +326,17 @@ class MITMProxy:
                                             p.topic, keypath,
                                             json.dumps(params, separators=(',', ':')),
                                         )
+                                    # Fan feature-parity capture: log every
+                                    # cloud-side setConfigField for fan/blower
+                                    # at INFO level on this branch so we can
+                                    # reverse-engineer the SF App's fan
+                                    # settings screen field-by-field.
+                                    if "fan" in keypath or "blower" in keypath:
+                                        logger.info(
+                                            "[FAN-CAPTURE] keyPath=%s params=%s",
+                                            keypath,
+                                            json.dumps(params, separators=(',', ':')),
+                                        )
                         except Exception as e:
                             # Never let logging break the relay
                             logger.debug("relay_down parse error (non-fatal): %s", e)

--- a/proxy/mitm_proxy.py
+++ b/proxy/mitm_proxy.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import logging
 import ssl
+import time
 from typing import Dict, Optional
 
 import paho.mqtt.client as mqtt
@@ -161,6 +162,50 @@ class MITMProxy:
             logger.info("config.yaml aktualisiert.")
         except Exception as e:
             logger.error("Fehler beim Speichern von config.yaml: %s", e)
+
+    async def config_poll_loop(self) -> None:
+        """Periodically inject getConfigField requests for light/light2/fan/
+        blower into every active controller session. If the controller
+        honors them, the responses come back through relay_up, get parsed
+        by _process_publish, and refresh the light_state / fan_state caches
+        without any user interaction. If the controller ignores them
+        (firmware-dependent), this is harmless.
+
+        Interval is configurable via proxy.config_poll_interval_sec
+        (default 600 = 10 minutes). Set to 0 to disable."""
+        interval = int(self.config.get("proxy", {}).get("config_poll_interval_sec", 600))
+        if interval <= 0:
+            logger.info("Config poll disabled (interval=%s)", interval)
+            return
+        logger.info("Config poll loop started, interval=%ds", interval)
+        # Initial delay so the first poll happens after sessions have had
+        # time to establish. Otherwise we'd inject into nothing.
+        await asyncio.sleep(min(60, interval))
+        while True:
+            try:
+                for sess in list(self._sessions.values()):
+                    for keypath in (["device", "light"], ["device", "light2"],
+                                    ["device", "fan"], ["device", "blower"]):
+                        try:
+                            await sess.inject({
+                                "method": "getConfigField",
+                                "pid": sess.mac,
+                                "params": {"keyPath": keypath},
+                                "msgId": str(int(time.time() * 1000)),
+                                "uid": sess.uid,
+                            })
+                        except Exception as e:
+                            logger.debug("config poll inject failed for %s: %s",
+                                         keypath, e)
+                        # Space out so we don't flood the controller in one burst
+                        await asyncio.sleep(0.5)
+                await asyncio.sleep(interval)
+            except asyncio.CancelledError:
+                logger.info("Config poll loop stopped")
+                break
+            except Exception as e:
+                logger.warning("Config poll loop error: %s", e)
+                await asyncio.sleep(30)
 
     async def handle_command(self, topic: str, value: str) -> None:
         """Handle an incoming HA command from local Mosquitto."""
@@ -448,8 +493,15 @@ def _process_publish(session: ProxySession, pkt, mqtt_client: mqtt.Client,
     except Exception:
         return
     method = data.get("method")
-    if method != "getDevSta":
+    # Accept any UP message that carries a data block — getDevSta is the
+    # main one, but getConfigField responses (when the controller honors
+    # them) come through here too. Setup-Acks without payload data fall
+    # through harmlessly because their "data" dict has no module blocks.
+    if method not in ("getDevSta", "getConfigField"):
         return
+    if method == "getConfigField":
+        logger.info("[CONFIG-RESP] data=%s",
+                    json.dumps(data.get("data", {}), separators=(',', ':'))[:500])
 
     # Keep UID up to date from controller messages
     uid = data.get("uid", "")
@@ -460,7 +512,19 @@ def _process_publish(session: ProxySession, pkt, mqtt_client: mqtt.Client,
     d = data.get("data", {})
     for module in ("light", "light2", "blower", "fan", "heater", "humidifier", "dehumidifier"):
         if module in d:
-            session.device_state[module] = d[module]
+            # Merge instead of replace — getDevSta on some firmwares carries
+            # only {on, level} for light/fan, which would wipe cached fields
+            # (modeType, schedule, etc) we need to keep.
+            session.device_state.setdefault(module, {}).update(d[module])
+    # Also feed light/fan caches from rich UP messages (getConfigField
+    # responses, full setConfigField echoes). Same merge semantics so
+    # minimal getDevSta echoes don't clobber the cached schedule/cycle.
+    for module in ("light", "light2"):
+        if module in d and isinstance(d[module], dict):
+            session.light_state.setdefault(module, {}).update(d[module])
+    for module in ("fan", "blower"):
+        if module in d and isinstance(d[module], dict):
+            session.fan_state.setdefault(module, {}).update(d[module])
 
     # Remember last non-zero brightness so OFF→ON restores the previous level
     for module in ("light", "light2"):

--- a/proxy/mitm_proxy.py
+++ b/proxy/mitm_proxy.py
@@ -11,7 +11,7 @@ from .mqtt_parser import (
     parse_packets, build_publish,
     MQTT_PUBLISH, MQTT_CONNECT, MQTT_SUBSCRIBE,
 )
-from .normalizer import normalize_status
+from .normalizer import normalize_status, fan_extras_topics
 from ha.discovery import (
     publish_soil_sensor_discovery as _publish_soil_sensor_discovery,
     unpublish_outlet_discovery as _unpublish_outlet_discovery,
@@ -49,6 +49,11 @@ class ProxySession:
         # Static discovery publishes outlets 1..10 unconditionally; once the
         # controller reports its actual outlet set we unpublish the rest.
         self._outlet_discovery_pruned: bool = False
+        # Full last-known fan/blower blocks for app-parity write paths.
+        # getDevSta carries only minimal state ({on, level}); cloud
+        # setConfigField traffic carries the schedule/cycle/speeds we
+        # need to merge against on HA writes.
+        self.fan_state: Dict[str, dict] = {}
 
     def set_upstream(self, writer: asyncio.StreamWriter) -> None:
         self._upstream_writer = writer
@@ -172,9 +177,20 @@ class MITMProxy:
 
         payload = translate_command(field, value, session.mac, session.uid, outlet_num,
                                     device_state=session.device_state, subfield=subfield,
-                                    last_nonzero_level=session.last_nonzero_level)
+                                    last_nonzero_level=session.last_nonzero_level,
+                                    fan_state=session.fan_state)
         if payload:
             await session.inject(payload)
+            # Optimistic update: write the fan/blower fields to the cache and
+            # publish per-field state topics so the new HA entities reflect
+            # the change without waiting for the next observed cloud echo.
+            params = payload.get("params", {})
+            for k in ("fan", "blower"):
+                blk = params.get(k)
+                if isinstance(blk, dict):
+                    session.fan_state[k] = blk
+                    for tpc, val in fan_extras_topics(session.device_id, k, blk).items():
+                        self.mqtt_client.publish(tpc, val, retain=True)
 
     async def handle_client(
         self,
@@ -337,6 +353,14 @@ class MITMProxy:
                                             keypath,
                                             json.dumps(params, separators=(',', ':')),
                                         )
+                                        sess = nonlocal_session[0]
+                                        if sess is not None:
+                                            for k in ("fan", "blower"):
+                                                if k in keypath and isinstance(params.get(k), dict):
+                                                    sess.fan_state[k] = params[k]
+                                                    for tpc, val in fan_extras_topics(
+                                                            sess.device_id, k, params[k]).items():
+                                                        self.mqtt_client.publish(tpc, val, retain=True)
                         except Exception as e:
                             # Never let logging break the relay
                             logger.debug("relay_down parse error (non-fatal): %s", e)

--- a/proxy/normalizer.py
+++ b/proxy/normalizer.py
@@ -89,7 +89,9 @@ def fan_extras_topics(device_id: str, prefix: str, block: Dict[str, Any]) -> Dic
     return out
 
 
-def normalize_status(device_id: str, data: Dict[str, Any]) -> Dict[str, str]:
+def normalize_status(device_id: str, data: Dict[str, Any],
+                     light_cache: Dict[str, dict] | None = None,
+                     fan_cache: Dict[str, dict] | None = None) -> Dict[str, str]:
     result: Dict[str, str] = {}
     d = data.get("data", data)
 
@@ -120,9 +122,16 @@ def normalize_status(device_id: str, data: Dict[str, Any]) -> Dict[str, str]:
             "effect": _LIGHT_MODES.get(lc_mode, str(lc_mode)),
         })
 
+    # Light blocks: getDevSta only carries {on, level} for some firmwares —
+    # no modeType. Falling back to a hard-coded default would flip HA's
+    # effect dropdown to the wrong mode whenever the controller sends a
+    # status update. Prefer the cached modeType from observed setConfigField
+    # traffic instead.
+    lc = light_cache or {}
+
     light = d.get("light", {})
     if light:
-        mode = light.get("modeType", 1)
+        mode = light.get("modeType", lc.get("light", {}).get("modeType", 0))
         result[f"spiderfarmer/{device_id}/state/light"] = json.dumps({
             "state": _on_off(light.get("on", light.get("mOnOff", 0))),
             "brightness": light.get("level", light.get("mLevel", 0)),
@@ -131,7 +140,7 @@ def normalize_status(device_id: str, data: Dict[str, Any]) -> Dict[str, str]:
 
     light2 = d.get("light2", {})
     if light2:
-        mode2 = light2.get("modeType", 1)
+        mode2 = light2.get("modeType", lc.get("light2", {}).get("modeType", 0))
         result[f"spiderfarmer/{device_id}/state/light2"] = json.dumps({
             "state": _on_off(light2.get("on", light2.get("mOnOff", 0))),
             "brightness": light2.get("level", light2.get("mLevel", 0)),

--- a/proxy/normalizer.py
+++ b/proxy/normalizer.py
@@ -13,9 +13,80 @@ _SENSOR_FIELD_MAP = [
     ("ECSoil", "ec_soil"),
 ]
 
+# modeType values for the fan block — confirmed from cloud setConfigField
+# captures while clicking through every mode in the SF App. The five Umwelt-
+# variants share modeType space with Manuell/Zeitfenster/Zyklus rather than
+# living in a separate Betriebsmodus field.
+_FAN_MODES = {
+    0: "Manual",
+    1: "Schedule",
+    2: "Cycle",
+    3: "Environment: Temperature only",
+    4: "Environment: Humidity only",
+    7: "Environment: Prioritize temperature",
+    8: "Environment: Prioritize humidity",
+    13: "Environment: Temperature & humidity",
+}
+
 
 def _on_off(val) -> str:
     return "ON" if val in (1, True, "1", "true", "on") else "OFF"
+
+
+def _seconds_to_hhmm(seconds) -> str:
+    try:
+        s = int(seconds) % 86400
+    except (TypeError, ValueError):
+        return "00:00"
+    return f"{s // 3600:02d}:{(s % 3600) // 60:02d}"
+
+
+def fan_extras_topics(device_id: str, prefix: str, block: Dict[str, Any]) -> Dict[str, str]:
+    """Per-field state topics for a fan/blower block. Used by normalize_status
+    when getDevSta arrives and by relay_down after observing a cloud
+    setConfigField, so the new HA entities (preset_mode, schedule, cycle,
+    speeds) get populated immediately."""
+    out: Dict[str, str] = {}
+    if not isinstance(block, dict):
+        return out
+    base = f"spiderfarmer/{device_id}/state/{prefix}"
+    if "modeType" in block:
+        mt = block["modeType"]
+        out[f"{base}/mode_label"] = _FAN_MODES.get(mt, str(mt))
+    if "maxSpeed" in block:
+        out[f"{base}/schedule_speed"] = str(block["maxSpeed"])
+    if "minSpeed" in block:
+        out[f"{base}/standby_speed"] = str(block["minSpeed"])
+    if "shakeLevel" in block:
+        out[f"{base}/oscillation_level"] = str(block["shakeLevel"])
+    if "natural" in block:
+        out[f"{base}/natural_wind"] = _on_off(block["natural"])
+    # Schedule-Modus (Zeitfenster) — timePeriod[0]
+    periods = block.get("timePeriod") or []
+    if isinstance(periods, list) and periods:
+        tp = periods[0] if isinstance(periods[0], dict) else {}
+        if "startTime" in tp:
+            out[f"{base}/schedule_start"] = _seconds_to_hhmm(tp["startTime"])
+        if "endTime" in tp:
+            out[f"{base}/schedule_end"] = _seconds_to_hhmm(tp["endTime"])
+    # Zyklusmodus
+    ct = block.get("cycleTime")
+    if isinstance(ct, dict):
+        if "startTime" in ct:
+            out[f"{base}/cycle_start"] = _seconds_to_hhmm(ct["startTime"])
+        if "openDur" in ct:
+            try:
+                out[f"{base}/cycle_run_minutes"] = str(int(ct["openDur"]) // 60)
+            except (TypeError, ValueError):
+                pass
+        if "closeDur" in ct:
+            try:
+                out[f"{base}/cycle_off_minutes"] = str(int(ct["closeDur"]) // 60)
+            except (TypeError, ValueError):
+                pass
+        if "times" in ct:
+            out[f"{base}/cycle_times"] = str(ct["times"])
+    return out
 
 
 def normalize_status(device_id: str, data: Dict[str, Any]) -> Dict[str, str]:
@@ -72,6 +143,7 @@ def normalize_status(device_id: str, data: Dict[str, Any]) -> Dict[str, str]:
             "state": _on_off(blower.get("on", blower.get("mOnOff", 0))),
             "percentage": blower.get("level", blower.get("mLevel", 0)),
         })
+        result.update(fan_extras_topics(device_id, "blower", blower))
 
     # ── Fan (JSON state + oscillation) ────────────────────────────────────────
     fan = d.get("fan", {})
@@ -80,6 +152,7 @@ def normalize_status(device_id: str, data: Dict[str, Any]) -> Dict[str, str]:
             "state": _on_off(fan.get("on", fan.get("mOnOff", 0))),
             "percentage": fan.get("level", fan.get("mLevel", 0)),
         })
+        result.update(fan_extras_topics(device_id, "fan", fan))
 
     # ── Accessories ───────────────────────────────────────────────────────────
     for module in ("heater", "humidifier", "dehumidifier"):

--- a/proxy/normalizer.py
+++ b/proxy/normalizer.py
@@ -41,6 +41,56 @@ def _seconds_to_hhmm(seconds) -> str:
     return f"{s // 3600:02d}:{(s % 3600) // 60:02d}"
 
 
+def light_extras_topics(device_id: str, prefix: str, block: Dict[str, Any]) -> Dict[str, str]:
+    """Per-field state topics for a light/light2 block. Used both by
+    normalize_status when getDevSta arrives and by relay_down / handle_command
+    after a setConfigField is observed/sent so the new HA entities populate
+    immediately. Mirror of fan_extras_topics, just for the light schema."""
+    out: Dict[str, str] = {}
+    if not isinstance(block, dict):
+        return out
+    base = f"spiderfarmer/{device_id}/state/{prefix}"
+    if "darkTemp" in block:
+        out[f"{base}/dim_threshold"] = str(block["darkTemp"])
+    if "offTemp" in block:
+        out[f"{base}/off_threshold"] = str(block["offTemp"])
+    # Schedule (Zeitfenstermodus) — timePeriod[0]
+    periods = block.get("timePeriod") or []
+    if isinstance(periods, list) and periods:
+        tp = periods[0] if isinstance(periods[0], dict) else {}
+        if "brightness" in tp:
+            out[f"{base}/schedule_brightness"] = str(tp["brightness"])
+        if "startTime" in tp:
+            out[f"{base}/schedule_start"] = _seconds_to_hhmm(tp["startTime"])
+        if "endTime" in tp:
+            out[f"{base}/schedule_end"] = _seconds_to_hhmm(tp["endTime"])
+        if "fadeTime" in tp:
+            try:
+                out[f"{base}/fade_minutes"] = str(int(tp["fadeTime"]) // 60)
+            except (TypeError, ValueError):
+                pass
+    # PPFD-Mode — own schedule + brightness limits
+    ppfd_periods = block.get("ppfdPeriod") or []
+    if isinstance(ppfd_periods, list) and ppfd_periods:
+        pp = ppfd_periods[0] if isinstance(ppfd_periods[0], dict) else {}
+        if "brightness" in pp:
+            out[f"{base}/ppfd_target"] = str(pp["brightness"])
+        if "startTime" in pp:
+            out[f"{base}/ppfd_start"] = _seconds_to_hhmm(pp["startTime"])
+        if "endTime" in pp:
+            out[f"{base}/ppfd_end"] = _seconds_to_hhmm(pp["endTime"])
+        if "fadeTime" in pp:
+            try:
+                out[f"{base}/ppfd_fade_minutes"] = str(int(pp["fadeTime"]) // 60)
+            except (TypeError, ValueError):
+                pass
+    if "ppfdMinBrightness" in block:
+        out[f"{base}/ppfd_min"] = str(block["ppfdMinBrightness"])
+    if "ppfdMaxBrightness" in block:
+        out[f"{base}/ppfd_max"] = str(block["ppfdMaxBrightness"])
+    return out
+
+
 def fan_extras_topics(device_id: str, prefix: str, block: Dict[str, Any]) -> Dict[str, str]:
     """Per-field state topics for a fan/blower block. Used by normalize_status
     when getDevSta arrives and by relay_down after observing a cloud
@@ -137,6 +187,11 @@ def normalize_status(device_id: str, data: Dict[str, Any],
             "brightness": light.get("level", light.get("mLevel", 0)),
             "effect": _LIGHT_MODES.get(mode, str(mode)),
         })
+        # Merge cached schedule/ppfd/temp fields into the block we hand to
+        # light_extras_topics — getDevSta on its own only carries on/level
+        # and would yield empty entities until the next setConfigField.
+        merged = {**lc.get("light", {}), **light}
+        result.update(light_extras_topics(device_id, "light", merged))
 
     light2 = d.get("light2", {})
     if light2:
@@ -146,6 +201,8 @@ def normalize_status(device_id: str, data: Dict[str, Any],
             "brightness": light2.get("level", light2.get("mLevel", 0)),
             "effect": _LIGHT_MODES.get(mode2, str(mode2)),
         })
+        merged2 = {**lc.get("light2", {}), **light2}
+        result.update(light_extras_topics(device_id, "light2", merged2))
 
     # ── Blower (JSON state) ───────────────────────────────────────────────────
     blower = d.get("blower", {})

--- a/proxy/normalizer.py
+++ b/proxy/normalizer.py
@@ -103,7 +103,9 @@ def normalize_status(device_id: str, data: Dict[str, Any]) -> Dict[str, str]:
     # Both modeType 0 (Manual) and 1 (Timer) map to the same UI label so the
     # effect dropdown in HA shows a known value regardless of which the
     # controller currently reports.
-    _LIGHT_MODES = {0: "Modus: Manual / Timer", 1: "Modus: Manual / Timer", 12: "Modus: PPFD"}
+    # modeType values confirmed against the SF App.
+    # 0 = Manual, 1 = Schedule (Zeitfenstermodus), 12 = PPFD.
+    _LIGHT_MODES = {0: "Manual", 1: "Schedule", 12: "PPFD"}
 
     # Standalone Light Controller (LC) reports light state flat at the top
     # level — `data.brightness` + `data.mode` instead of nested under

--- a/spiderbridge/app/ha/discovery.py
+++ b/spiderbridge/app/ha/discovery.py
@@ -143,7 +143,7 @@ def _light(device_id: str, module: str, name: str, cfg: dict) -> Tuple[str, dict
         "brightness": True,
         "brightness_scale": 100,
         "effect": True,
-        "effect_list": ["Modus: Manual / Timer", "Modus: PPFD"],
+        "effect_list": ["Manual", "Schedule", "PPFD"],
         "availability_topic": f"{base}/availability",
         "device": _device_info(device_id, cfg),
     }
@@ -232,16 +232,15 @@ def _fan_extras(device_id: str, module: str, friendly: str, cfg: dict) -> list:
                      "Off Time", 0, 1440, 1, cfg, unit="min", device=cycle_dev),
         _number_path(device_id, module, "cycle_times",
                      "Cycles", 1, 100, 1, cfg, device=cycle_dev),
-        # Speeds
+        # Speeds (catch-all fan settings — applies across all modes)
         _number_path(device_id, module, "schedule_speed",
                      "Speed", 1, 10, 1, cfg, device=speeds_dev),
         _number_path(device_id, module, "standby_speed",
                      "Standby Speed", 0, 10, 1, cfg, device=speeds_dev),
         _number_path(device_id, module, "oscillation_level",
                      "Oscillation", 0, 10, 1, cfg, device=speeds_dev),
-        # Natural wind sits on the main device.
         _switch_path(device_id, module, "natural_wind",
-                     f"{friendly} Natural Wind", cfg),
+                     "Natural Wind", cfg, device=speeds_dev),
     ]
 
 

--- a/spiderbridge/app/ha/discovery.py
+++ b/spiderbridge/app/ha/discovery.py
@@ -64,6 +64,73 @@ def _switch(device_id: str, field: str, name: str, cfg: dict) -> Tuple[str, dict
     return f"homeassistant/switch/{uid}/config", payload
 
 
+def _number_path(device_id: str, path: str, suffix: str, name: str,
+                 min_val, max_val, step, cfg: dict, unit: str | None = None,
+                 device: dict | None = None) -> Tuple[str, dict]:
+    uid = f"spiderfarmer_{device_id}_{path}_{suffix}"
+    payload = {
+        "name": name,
+        "unique_id": uid,
+        "state_topic": f"spiderfarmer/{device_id}/state/{path}/{suffix}",
+        "command_topic": f"spiderfarmer/{device_id}/command/{path}/{suffix}/set",
+        "availability_topic": f"spiderfarmer/{device_id}/availability",
+        "min": min_val,
+        "max": max_val,
+        "step": step,
+        "entity_category": "config",
+        "device": device or _device_info(device_id, cfg),
+    }
+    if unit:
+        payload["unit_of_measurement"] = unit
+    return f"homeassistant/number/{uid}/config", payload
+
+
+def _text_path(device_id: str, path: str, suffix: str, name: str, pattern: str,
+               cfg: dict, device: dict | None = None) -> Tuple[str, dict]:
+    uid = f"spiderfarmer_{device_id}_{path}_{suffix}"
+    payload = {
+        "name": name,
+        "unique_id": uid,
+        "state_topic": f"spiderfarmer/{device_id}/state/{path}/{suffix}",
+        "command_topic": f"spiderfarmer/{device_id}/command/{path}/{suffix}/set",
+        "availability_topic": f"spiderfarmer/{device_id}/availability",
+        "pattern": pattern,
+        "entity_category": "config",
+        "device": device or _device_info(device_id, cfg),
+    }
+    return f"homeassistant/text/{uid}/config", payload
+
+
+def _switch_path(device_id: str, path: str, suffix: str, name: str, cfg: dict,
+                 device: dict | None = None) -> Tuple[str, dict]:
+    uid = f"spiderfarmer_{device_id}_{path}_{suffix}"
+    payload = {
+        "name": name,
+        "unique_id": uid,
+        "state_topic": f"spiderfarmer/{device_id}/state/{path}/{suffix}",
+        "command_topic": f"spiderfarmer/{device_id}/command/{path}/{suffix}/set",
+        "availability_topic": f"spiderfarmer/{device_id}/availability",
+        "payload_on": "ON",
+        "payload_off": "OFF",
+        "device": device or _device_info(device_id, cfg),
+    }
+    return f"homeassistant/switch/{uid}/config", payload
+
+
+def _settings_subdevice(parent_id: str, parent_name: str, slug: str,
+                        suffix_name: str, model: str) -> dict:
+    """HA MQTT device-info for a settings sub-device, linked to the main
+    controller via via_device so HA renders it as a separate card on the
+    parent's device page."""
+    return {
+        "identifiers": [f"{parent_id}_{slug}"],
+        "name": f"{parent_name} {suffix_name}",
+        "manufacturer": "Spider Farmer",
+        "model": model,
+        "via_device": parent_id,
+    }
+
+
 def _light(device_id: str, module: str, name: str, cfg: dict) -> Tuple[str, dict]:
     uid = f"spiderfarmer_{device_id}_{module}"
     base = f"spiderfarmer/{device_id}"
@@ -83,8 +150,20 @@ def _light(device_id: str, module: str, name: str, cfg: dict) -> Tuple[str, dict
     return f"homeassistant/light/{uid}/config", payload
 
 
+_FAN_PRESET_MODES = [
+    "Manual",
+    "Schedule",
+    "Cycle",
+    "Environment: Prioritize temperature",
+    "Environment: Prioritize humidity",
+    "Environment: Temperature only",
+    "Environment: Humidity only",
+    "Environment: Temperature & humidity",
+]
+
+
 def _fan(device_id: str, module: str, name: str, speed_max: int, cfg: dict,
-         oscillation: bool = False) -> Tuple[str, dict]:
+         oscillation: bool = False, preset_modes: bool = False) -> Tuple[str, dict]:
     uid = f"spiderfarmer_{device_id}_{module}"
     base = f"spiderfarmer/{device_id}"
     payload = {
@@ -111,7 +190,59 @@ def _fan(device_id: str, module: str, name: str, speed_max: int, cfg: dict,
             "payload_oscillation_on": "oscillate_on",
             "payload_oscillation_off": "oscillate_off",
         })
+    if preset_modes:
+        # Mirror the SF App's Modus dropdown — 8 modes including 5 Umwelt
+        # variants. Selection routes back via /command/{module}/preset_mode/set
+        # and resolves to the matching modeType in command_handler.
+        payload.update({
+            "preset_mode_state_topic": f"{base}/state/{module}/mode_label",
+            "preset_mode_command_topic": f"{base}/command/{module}/preset_mode/set",
+            "preset_modes": list(_FAN_PRESET_MODES),
+        })
     return f"homeassistant/fan/{uid}/config", payload
+
+
+def _fan_extras(device_id: str, module: str, friendly: str, cfg: dict) -> list:
+    """Sub-device entities mirroring the SF App's Lüfter-Einstellungen screen
+    for one fan/blower. Three sub-devices linked via via_device:
+      - Zeitfenstermodus: schedule_start, schedule_end
+      - Zyklusmodus: cycle_start, cycle_run, cycle_off, cycle_times
+      - Geschwindigkeiten: schedule_speed, standby_speed, oscillation_level
+    Plus a switch on the main device for natural_wind."""
+    parent_id = f"spiderfarmer_{device_id}"
+    sched_dev = _settings_subdevice(parent_id, friendly, f"{module}_schedule",
+                                    "Schedule Mode", "Schedule settings")
+    cycle_dev = _settings_subdevice(parent_id, friendly, f"{module}_cycle",
+                                    "Cycle Mode", "Cycle settings")
+    speeds_dev = _settings_subdevice(parent_id, friendly, f"{module}_speeds",
+                                     "Speeds", "Speed settings")
+    HHMM = r"^([01]\d|2[0-3]):[0-5]\d$"
+    return [
+        # Schedule Mode
+        _text_path(device_id, module, "schedule_start",
+                   "Start Time", HHMM, cfg, device=sched_dev),
+        _text_path(device_id, module, "schedule_end",
+                   "End Time", HHMM, cfg, device=sched_dev),
+        # Cycle Mode
+        _text_path(device_id, module, "cycle_start",
+                   "Start Time", HHMM, cfg, device=cycle_dev),
+        _number_path(device_id, module, "cycle_run_minutes",
+                     "Run Time", 0, 1440, 1, cfg, unit="min", device=cycle_dev),
+        _number_path(device_id, module, "cycle_off_minutes",
+                     "Off Time", 0, 1440, 1, cfg, unit="min", device=cycle_dev),
+        _number_path(device_id, module, "cycle_times",
+                     "Cycles", 1, 100, 1, cfg, device=cycle_dev),
+        # Speeds
+        _number_path(device_id, module, "schedule_speed",
+                     "Speed", 1, 10, 1, cfg, device=speeds_dev),
+        _number_path(device_id, module, "standby_speed",
+                     "Standby Speed", 0, 10, 1, cfg, device=speeds_dev),
+        _number_path(device_id, module, "oscillation_level",
+                     "Oscillation", 0, 10, 1, cfg, device=speeds_dev),
+        # Natural wind sits on the main device.
+        _switch_path(device_id, module, "natural_wind",
+                     f"{friendly} Natural Wind", cfg),
+    ]
 
 
 def publish_discovery_for_device(
@@ -136,8 +267,14 @@ def publish_discovery_for_device(
     entities.append(_light(device_id, "light2", "Light 2", device_cfg))
 
     # ── Fans ──────────────────────────────────────────────────────────────────
-    entities.append(_fan(device_id, "blower", "Fan Exhaust",     100, device_cfg))
-    entities.append(_fan(device_id, "fan", "Fan Circulation", 10, device_cfg))
+    entities.append(_fan(device_id, "blower", "Fan Exhaust", 100, device_cfg))
+    # Fan Circulation gets the new app-parity entities: preset_modes on the
+    # main fan plus three sub-devices (Schedule Mode, Cycle Mode, Speeds)
+    # and a switch for natural wind. Fan Exhaust (blower) is intentionally
+    # left as the simple variant for now — same pattern, follow-up.
+    entities.append(_fan(device_id, "fan", "Fan Circulation", 10, device_cfg,
+                         preset_modes=True))
+    entities += _fan_extras(device_id, "fan", "Fan", device_cfg)
 
     # ── Soil sensors (average) ────────────────────────────────────────────────
     entities += [

--- a/spiderbridge/app/ha/discovery.py
+++ b/spiderbridge/app/ha/discovery.py
@@ -117,6 +117,32 @@ def _switch_path(device_id: str, path: str, suffix: str, name: str, cfg: dict,
     return f"homeassistant/switch/{uid}/config", payload
 
 
+def _number_path_aliased(device_id: str, path: str, suffix: str, alias: str,
+                         name: str, min_val, max_val, step, cfg: dict,
+                         unit: str | None = None,
+                         device: dict | None = None) -> Tuple[str, dict]:
+    """Like _number_path but lets the unique_id diverge from the topic. Used
+    to expose the same temperature-protection fields under two sub-devices
+    (Schedule and PPFD) — both control the same controller field, so the
+    state and command topics match, but HA needs distinct unique_ids."""
+    uid = f"spiderfarmer_{device_id}_{path}_{suffix}_{alias}"
+    payload = {
+        "name": name,
+        "unique_id": uid,
+        "state_topic": f"spiderfarmer/{device_id}/state/{path}/{suffix}",
+        "command_topic": f"spiderfarmer/{device_id}/command/{path}/{suffix}/set",
+        "availability_topic": f"spiderfarmer/{device_id}/availability",
+        "min": min_val,
+        "max": max_val,
+        "step": step,
+        "entity_category": "config",
+        "device": device or _device_info(device_id, cfg),
+    }
+    if unit:
+        payload["unit_of_measurement"] = unit
+    return f"homeassistant/number/{uid}/config", payload
+
+
 def _settings_subdevice(parent_id: str, parent_name: str, slug: str,
                         suffix_name: str, model: str) -> dict:
     """HA MQTT device-info for a settings sub-device, linked to the main
@@ -202,6 +228,65 @@ def _fan(device_id: str, module: str, name: str, speed_max: int, cfg: dict,
     return f"homeassistant/fan/{uid}/config", payload
 
 
+def _light_extras(device_id: str, module: str, friendly: str, cfg: dict) -> list:
+    """Sub-device entities mirroring the SF App's "Lampe Einstellungen" screen
+    for one light. Two sub-devices linked via via_device:
+      - Schedule Mode: schedule_brightness, schedule_start/end, fade_minutes,
+        plus the Temperaturschutz fields (dim/off thresholds).
+      - PPFD Mode: ppfd_target/min/max/start/end/fade_minutes, plus the same
+        Temperaturschutz fields (per user request — Temperaturschutz applies
+        in both modes, so it is exposed in both groups rather than a
+        separate settings card).
+    Note: dim_threshold/off_threshold appear under each sub-device with
+    distinct unique_ids but identical state/command topics, so HA shows
+    them in both cards while a single change keeps them synchronized."""
+    parent_id = f"spiderfarmer_{device_id}"
+    sched_dev = _settings_subdevice(parent_id, friendly, f"{module}_schedule",
+                                    "Schedule Mode", "Schedule settings")
+    ppfd_dev = _settings_subdevice(parent_id, friendly, f"{module}_ppfd",
+                                   "PPFD Mode", "PPFD settings")
+    HHMM = r"^([01]\d|2[0-3]):[0-5]\d$"
+    return [
+        # Schedule Mode
+        _number_path(device_id, module, "schedule_brightness",
+                     "Brightness", 0, 100, 1, cfg, unit="%", device=sched_dev),
+        _text_path(device_id, module, "schedule_start",
+                   "Start Time", HHMM, cfg, device=sched_dev),
+        _text_path(device_id, module, "schedule_end",
+                   "End Time", HHMM, cfg, device=sched_dev),
+        _number_path(device_id, module, "fade_minutes",
+                     "Fade Time", 0, 240, 1, cfg, unit="min", device=sched_dev),
+        # Temperaturschutz under Schedule
+        _number_path_aliased(device_id, module, "dim_threshold", "schedule",
+                             "Dim Threshold", 0, 50, 0.1, cfg,
+                             unit="°C", device=sched_dev),
+        _number_path_aliased(device_id, module, "off_threshold", "schedule",
+                             "Off Threshold", 0, 50, 0.1, cfg,
+                             unit="°C", device=sched_dev),
+        # PPFD Mode
+        _number_path(device_id, module, "ppfd_target",
+                     "Target PPFD", 0, 1000, 1, cfg,
+                     unit="µmol/m²/s", device=ppfd_dev),
+        _number_path(device_id, module, "ppfd_min",
+                     "Min Brightness", 0, 100, 1, cfg, unit="%", device=ppfd_dev),
+        _number_path(device_id, module, "ppfd_max",
+                     "Max Brightness", 0, 100, 1, cfg, unit="%", device=ppfd_dev),
+        _text_path(device_id, module, "ppfd_start",
+                   "Start Time", HHMM, cfg, device=ppfd_dev),
+        _text_path(device_id, module, "ppfd_end",
+                   "End Time", HHMM, cfg, device=ppfd_dev),
+        _number_path(device_id, module, "ppfd_fade_minutes",
+                     "Fade Time", 0, 240, 1, cfg, unit="min", device=ppfd_dev),
+        # Temperaturschutz under PPFD (same topics, distinct unique_id)
+        _number_path_aliased(device_id, module, "dim_threshold", "ppfd",
+                             "Dim Threshold", 0, 50, 0.1, cfg,
+                             unit="°C", device=ppfd_dev),
+        _number_path_aliased(device_id, module, "off_threshold", "ppfd",
+                             "Off Threshold", 0, 50, 0.1, cfg,
+                             unit="°C", device=ppfd_dev),
+    ]
+
+
 def _fan_extras(device_id: str, module: str, friendly: str, cfg: dict) -> list:
     """Sub-device entities mirroring the SF App's Lüfter-Einstellungen screen
     for one fan/blower. Three sub-devices linked via via_device:
@@ -262,7 +347,11 @@ def publish_discovery_for_device(
     ]
 
     # ── Light ─────────────────────────────────────────────────────────────────
+    # Light 1 gets the new app-parity entities (Schedule Mode + PPFD Mode
+    # sub-devices). Light 2 stays as the simple variant — only Light 1 was
+    # exposed via the SF App's settings screen the user mirrored.
     entities.append(_light(device_id, "light",  "Light 1", device_cfg))
+    entities += _light_extras(device_id, "light", "Light 1", device_cfg)
     entities.append(_light(device_id, "light2", "Light 2", device_cfg))
 
     # ── Fans ──────────────────────────────────────────────────────────────────

--- a/spiderbridge/app/main_proxy.py
+++ b/spiderbridge/app/main_proxy.py
@@ -52,9 +52,19 @@ def main() -> None:
         loop.add_signal_handler(signal.SIGTERM, stop.set)
         loop.add_signal_handler(signal.SIGINT, stop.set)
 
+        # Background config polling — pulls fresh light/fan/blower config
+        # from active controllers every N minutes so HA stays in sync with
+        # SF-App-side changes the user makes without HA interaction.
+        poll_task = asyncio.create_task(proxy.config_poll_loop())
+
         logger.info("Proxy listening on %s:%s", pcfg["listen_host"], pcfg["listen_port"])
         async with server:
             await stop.wait()
+        poll_task.cancel()
+        try:
+            await poll_task
+        except asyncio.CancelledError:
+            pass
         logger.info("Shutting down")
 
     try:

--- a/spiderbridge/app/proxy/command_handler.py
+++ b/spiderbridge/app/proxy/command_handler.py
@@ -154,10 +154,16 @@ def translate_command(
                 tp.append({})
             tp[0]["endTime"] = _hhmm_to_seconds(value)
         elif subfield == "schedule_speed":
+            # The controller uses different fields for the active speed
+            # depending on mode: mLevel in Manual, maxSpeed in
+            # Schedule/Cycle/Environment. Write both so a single HA "Speed"
+            # entity actually changes the fan regardless of current mode.
             try:
-                block["maxSpeed"] = max(1, min(10, int(float(value))))
+                v = max(1, min(10, int(float(value))))
             except (ValueError, TypeError):
                 return None
+            block["maxSpeed"] = v
+            block["mLevel"] = v
         elif subfield == "standby_speed":
             try:
                 block["minSpeed"] = max(0, min(10, int(float(value))))

--- a/spiderbridge/app/proxy/command_handler.py
+++ b/spiderbridge/app/proxy/command_handler.py
@@ -7,9 +7,34 @@ logger = logging.getLogger(__name__)
 
 _TIME_PERIOD = [{"weekmask": 127}]
 
+# Reverse mapping of the fan modeType labels surfaced as preset_modes in HA.
+# Order here matches the SF App dropdown so the HA UI lists modes in the
+# same order the user sees in the App.
+_FAN_MODE_TO_TYPE = {
+    "Manual": 0,
+    "Schedule": 1,
+    "Cycle": 2,
+    "Environment: Prioritize temperature": 7,
+    "Environment: Prioritize humidity": 8,
+    "Environment: Temperature only": 3,
+    "Environment: Humidity only": 4,
+    "Environment: Temperature & humidity": 13,
+}
+
 
 def _onoff(v) -> int:
     return 1 if str(v).upper() in ("ON", "1", "TRUE") else 0
+
+
+def _hhmm_to_seconds(s) -> int:
+    """Parse 'HH:MM' to seconds since midnight; 0 on parse error."""
+    try:
+        parts = str(s).split(":")
+        h = int(parts[0])
+        m = int(parts[1]) if len(parts) > 1 else 0
+        return (h * 3600 + m * 60) % 86400
+    except (ValueError, IndexError):
+        return 0
 
 
 def _build(mac: str, uid: str, domain: str, module: str, obj: dict) -> dict:
@@ -31,9 +56,11 @@ def translate_command(
     device_state: Optional[dict] = None,
     subfield: Optional[str] = None,
     last_nonzero_level: Optional[dict] = None,
+    fan_state: Optional[dict] = None,
 ) -> Optional[dict]:
     state = device_state or {}
     last_levels = last_nonzero_level or {}
+    fans = fan_state or {}
 
     # ── Outlet ────────────────────────────────────────────────────────────────
     # Minimal payload — the controller already has the schedule/watering
@@ -74,6 +101,98 @@ def translate_command(
             "mLevel": level,
             "timePeriod": cur.get("timePeriod", _TIME_PERIOD),
         })
+
+    # ── Fan / Blower — app-parity subfield writes ───────────────────────────
+    # New HA entities (preset_mode, schedule_*, cycle_*, schedule_speed,
+    # standby_speed, oscillation_level, natural_wind) each map to one field
+    # on the controller's fan/blower block. Merge the subfield into a copy
+    # of the cached block so the rest of the controller's settings stay
+    # intact. When the cache is empty, synthesize a sensible default block
+    # so the controller does not silently reject the partial command.
+    _FAN_SUBFIELDS = {
+        "preset_mode", "schedule_start", "schedule_end",
+        "schedule_speed", "standby_speed",
+        "cycle_start", "cycle_run_minutes", "cycle_off_minutes", "cycle_times",
+        "oscillation_level", "natural_wind",
+    }
+    if field in ("fan", "blower") and subfield in _FAN_SUBFIELDS:
+        cached = fans.get(field)
+        if cached:
+            block = dict(cached)
+        else:
+            cur = state.get(field, {})
+            block = {
+                "modeType": cur.get("modeType", 0),
+                "mOnOff": int(cur.get("on", cur.get("mOnOff", 0))),
+                "mLevel": int(cur.get("level", cur.get("mLevel", 1))),
+                "shakeLevel": int(cur.get("shakeLevel", 0)),
+                "natural": 0,
+                "minSpeed": 0,
+                "maxSpeed": 1,
+                "timePeriod": [{"enabled": 1, "weekmask": 127, "startTime": 0, "endTime": 0}],
+                "cycleTime": {"weekmask": 127, "startTime": 0, "openDur": 0, "closeDur": 0, "times": 1},
+            }
+            logger.info(
+                "[%s] Fan cache empty — using synthesized defaults for %s/%s",
+                field, field, subfield,
+            )
+
+        if subfield == "preset_mode":
+            mt = _FAN_MODE_TO_TYPE.get(value)
+            if mt is None:
+                logger.warning("Unknown fan preset_mode: %s", value)
+                return None
+            block["modeType"] = mt
+        elif subfield == "schedule_start":
+            tp = block.setdefault("timePeriod", [{}])
+            if not tp:
+                tp.append({})
+            tp[0]["startTime"] = _hhmm_to_seconds(value)
+        elif subfield == "schedule_end":
+            tp = block.setdefault("timePeriod", [{}])
+            if not tp:
+                tp.append({})
+            tp[0]["endTime"] = _hhmm_to_seconds(value)
+        elif subfield == "schedule_speed":
+            try:
+                block["maxSpeed"] = max(1, min(10, int(float(value))))
+            except (ValueError, TypeError):
+                return None
+        elif subfield == "standby_speed":
+            try:
+                block["minSpeed"] = max(0, min(10, int(float(value))))
+            except (ValueError, TypeError):
+                return None
+        elif subfield == "cycle_start":
+            ct = block.setdefault("cycleTime", {"weekmask": 127})
+            ct["startTime"] = _hhmm_to_seconds(value)
+        elif subfield == "cycle_run_minutes":
+            ct = block.setdefault("cycleTime", {"weekmask": 127})
+            try:
+                ct["openDur"] = max(0, int(float(value))) * 60
+            except (ValueError, TypeError):
+                return None
+        elif subfield == "cycle_off_minutes":
+            ct = block.setdefault("cycleTime", {"weekmask": 127})
+            try:
+                ct["closeDur"] = max(0, int(float(value))) * 60
+            except (ValueError, TypeError):
+                return None
+        elif subfield == "cycle_times":
+            ct = block.setdefault("cycleTime", {"weekmask": 127})
+            try:
+                # Controller hard-caps at 100 regardless of cycle duration.
+                ct["times"] = max(1, min(100, int(float(value))))
+            except (ValueError, TypeError):
+                return None
+        elif subfield == "oscillation_level":
+            try:
+                block["shakeLevel"] = max(0, min(10, int(float(value))))
+            except (ValueError, TypeError):
+                return None
+        elif subfield == "natural_wind":
+            block["natural"] = _onoff(value)
+        return _build(mac, uid, "device", field, block)
 
     # ── Blower on/off ─────────────────────────────────────────────────────────
     if field == "blower" and subfield is None:

--- a/spiderbridge/app/proxy/command_handler.py
+++ b/spiderbridge/app/proxy/command_handler.py
@@ -57,10 +57,12 @@ def translate_command(
     subfield: Optional[str] = None,
     last_nonzero_level: Optional[dict] = None,
     fan_state: Optional[dict] = None,
+    light_state: Optional[dict] = None,
 ) -> Optional[dict]:
     state = device_state or {}
     last_levels = last_nonzero_level or {}
     fans = fan_state or {}
+    lights = light_state or {}
 
     # ── Outlet ────────────────────────────────────────────────────────────────
     # Minimal payload — the controller already has the schedule/watering
@@ -70,6 +72,108 @@ def translate_command(
     if outlet_num is not None:
         ok = f"O{outlet_num}"
         return _build(mac, uid, "outlet", ok, {"modeType": 0, "mOnOff": _onoff(value)})
+
+    # ── Light / Light2 — app-parity subfield writes ─────────────────────────
+    # Mirror the SF App's "Lampe Einstellungen" screen. Each HA entity (text/
+    # number/switch under /command/light/<subfield>/set) maps to one field on
+    # the controller's light/light2 block. Merge the subfield into a copy of
+    # the cached block so the rest of the lamp's settings stay intact. When
+    # the cache is empty, synthesize a default block so the controller does
+    # not silently reject the partial command.
+    _LIGHT_SUBFIELDS = {
+        "dim_threshold", "off_threshold",
+        "schedule_brightness", "schedule_start", "schedule_end", "fade_minutes",
+        "ppfd_target", "ppfd_start", "ppfd_end", "ppfd_fade_minutes",
+        "ppfd_min", "ppfd_max",
+    }
+    if field in ("light", "light2") and subfield in _LIGHT_SUBFIELDS:
+        cached = lights.get(field)
+        if cached:
+            block = dict(cached)
+        else:
+            cur = state.get(field, {})
+            block = {
+                "modeType": cur.get("modeType", 0),
+                "lastAutoModeType": cur.get("lastAutoModeType", 0),
+                "mOnOff": int(cur.get("on", cur.get("mOnOff", 0))),
+                "mLevel": int(cur.get("level", cur.get("mLevel", 0))),
+                "darkTemp": 0,
+                "offTemp": 0,
+                "timePeriod": [{"enabled": 1, "weekmask": 127,
+                                "startTime": 0, "endTime": 0,
+                                "brightness": 0, "fadeTime": 0}],
+                "ppfdPeriod": [{"enabled": 0, "weekmask": 127,
+                                "startTime": 0, "endTime": 0,
+                                "brightness": 0, "fadeTime": 0}],
+                "ppfdMinBrightness": 0,
+                "ppfdMaxBrightness": 100,
+            }
+            logger.info(
+                "Light cache empty — using synthesized defaults for %s/%s",
+                field, subfield,
+            )
+
+        def _tp0():
+            tp = block.setdefault("timePeriod", [{}])
+            if not tp:
+                tp.append({})
+            return tp[0]
+
+        def _pp0():
+            pp = block.setdefault("ppfdPeriod", [{}])
+            if not pp:
+                pp.append({})
+            return pp[0]
+
+        if subfield == "dim_threshold":
+            try:
+                block["darkTemp"] = float(value)
+            except (ValueError, TypeError):
+                return None
+        elif subfield == "off_threshold":
+            try:
+                block["offTemp"] = float(value)
+            except (ValueError, TypeError):
+                return None
+        elif subfield == "schedule_brightness":
+            try:
+                _tp0()["brightness"] = max(0, min(100, int(float(value))))
+            except (ValueError, TypeError):
+                return None
+        elif subfield == "schedule_start":
+            _tp0()["startTime"] = _hhmm_to_seconds(value)
+        elif subfield == "schedule_end":
+            _tp0()["endTime"] = _hhmm_to_seconds(value)
+        elif subfield == "fade_minutes":
+            try:
+                _tp0()["fadeTime"] = max(0, int(float(value))) * 60
+            except (ValueError, TypeError):
+                return None
+        elif subfield == "ppfd_target":
+            try:
+                _pp0()["brightness"] = max(0, min(1000, int(float(value))))
+            except (ValueError, TypeError):
+                return None
+        elif subfield == "ppfd_start":
+            _pp0()["startTime"] = _hhmm_to_seconds(value)
+        elif subfield == "ppfd_end":
+            _pp0()["endTime"] = _hhmm_to_seconds(value)
+        elif subfield == "ppfd_fade_minutes":
+            try:
+                _pp0()["fadeTime"] = max(0, int(float(value))) * 60
+            except (ValueError, TypeError):
+                return None
+        elif subfield == "ppfd_min":
+            try:
+                block["ppfdMinBrightness"] = max(0, min(100, int(float(value))))
+            except (ValueError, TypeError):
+                return None
+        elif subfield == "ppfd_max":
+            try:
+                block["ppfdMaxBrightness"] = max(0, min(100, int(float(value))))
+            except (ValueError, TypeError):
+                return None
+        return _build(mac, uid, "device", field, block)
 
     # ── Light / Light2 ────────────────────────────────────────────────────────
     # The SF cloud always sends modeType=0 (Manual) for direct app control —

--- a/spiderbridge/app/proxy/command_handler.py
+++ b/spiderbridge/app/proxy/command_handler.py
@@ -76,7 +76,14 @@ def translate_command(
     # mode 1 (Timer) makes the controller follow the stored schedule and
     # ignore mOnOff/mLevel. Mirror the cloud's payload shape so HA actually
     # controls the lamp instead of fighting the schedule.
-    _EFFECT_TO_MODE = {"Modus: Manual / Timer": 0, "Modus: PPFD": 12}
+    # Mode label ↔ modeType, confirmed against SF App. Old "Manual / Timer"
+    # alias kept so HA selects from previous installs still resolve.
+    _EFFECT_TO_MODE = {
+        "Manual": 0,
+        "Schedule": 1,
+        "PPFD": 12,
+        "Modus: Manual / Timer": 0,
+    }
     if field in ("light", "light2"):
         cur = state.get(field, {})
         try:

--- a/spiderbridge/app/proxy/mitm_proxy.py
+++ b/spiderbridge/app/proxy/mitm_proxy.py
@@ -331,6 +331,12 @@ class MITMProxy:
                                             p.topic, keypath,
                                             json.dumps(params, separators=(',', ':')),
                                         )
+                                    if "fan" in keypath or "blower" in keypath:
+                                        logger.info(
+                                            "[FAN-CAPTURE] keyPath=%s params=%s",
+                                            keypath,
+                                            json.dumps(params, separators=(',', ':')),
+                                        )
                         except Exception as e:
                             logger.debug("relay_down parse error (non-fatal): %s", e)
                             buf_down = b""

--- a/spiderbridge/app/proxy/mitm_proxy.py
+++ b/spiderbridge/app/proxy/mitm_proxy.py
@@ -164,35 +164,39 @@ class MITMProxy:
             except Exception as e:
                 logger.error("Fehler beim Speichern von config.yaml: %s", e)
 
+    async def poll_session_config(self, sess: ProxySession) -> None:
+        """One round of getConfigField for all 4 modules on one session."""
+        for keypath in (["device", "light"], ["device", "light2"],
+                        ["device", "fan"], ["device", "blower"]):
+            try:
+                await sess.inject({
+                    "method": "getConfigField",
+                    "pid": sess.mac,
+                    "params": {"keyPath": keypath},
+                    "msgId": str(int(time.time() * 1000)),
+                    "uid": sess.uid,
+                })
+            except Exception as e:
+                logger.debug("config poll inject failed for %s: %s", keypath, e)
+            await asyncio.sleep(0.5)
+
     async def config_poll_loop(self) -> None:
-        """Periodically inject getConfigField requests into every active
-        controller session so HA caches stay fresh even when the user only
-        touches the SF App. Interval is configurable via
-        proxy.config_poll_interval_sec (default 600 = 10 minutes; 0 disables)."""
+        """Periodic ticker. Sessions also get an immediate one-shot poll on
+        connect (handle_client) so HA caches refresh straight after
+        restart/reconnect instead of waiting for the first interval tick.
+
+        Interval is configurable via proxy.config_poll_interval_sec
+        (default 600 = 10 minutes; 0 disables)."""
         interval = int(self.config.get("proxy", {}).get("config_poll_interval_sec", 600))
         if interval <= 0:
             logger.info("Config poll disabled (interval=%s)", interval)
             return
         logger.info("Config poll loop started, interval=%ds", interval)
-        await asyncio.sleep(min(60, interval))
         while True:
             try:
-                for sess in list(self._sessions.values()):
-                    for keypath in (["device", "light"], ["device", "light2"],
-                                    ["device", "fan"], ["device", "blower"]):
-                        try:
-                            await sess.inject({
-                                "method": "getConfigField",
-                                "pid": sess.mac,
-                                "params": {"keyPath": keypath},
-                                "msgId": str(int(time.time() * 1000)),
-                                "uid": sess.uid,
-                            })
-                        except Exception as e:
-                            logger.debug("config poll inject failed for %s: %s",
-                                         keypath, e)
-                        await asyncio.sleep(0.5)
                 await asyncio.sleep(interval)
+                for sess in list(self._sessions.values()):
+                    await self.poll_session_config(sess)
             except asyncio.CancelledError:
                 logger.info("Config poll loop stopped")
                 break
@@ -279,6 +283,12 @@ class MITMProxy:
                 self._sessions[s.device_id] = s
                 s.publish_availability("online")
                 logger.info("Session erstellt: device_id=%s mac=%s", s.device_id, s.mac)
+                # Immediate one-shot config poll so HA caches refresh on
+                # restart/reconnect rather than waiting for the next tick.
+                async def _initial_poll():
+                    await asyncio.sleep(3)
+                    await self.poll_session_config(s)
+                asyncio.create_task(_initial_poll())
                 return s
 
             async def relay_up():

--- a/spiderbridge/app/proxy/mitm_proxy.py
+++ b/spiderbridge/app/proxy/mitm_proxy.py
@@ -53,6 +53,7 @@ class ProxySession:
         self._outlet_discovery_pruned: bool = False
         # Full last-known fan/blower blocks for app-parity write paths.
         self.fan_state: Dict[str, dict] = {}
+        self.light_state: Dict[str, dict] = {}
 
     def set_upstream(self, writer: asyncio.StreamWriter) -> None:
         self._upstream_writer = writer
@@ -193,6 +194,16 @@ class MITMProxy:
                 if isinstance(blk, dict):
                     session.fan_state[k] = blk
                     for tpc, val in fan_extras_topics(session.device_id, k, blk).items():
+                        self.mqtt_client.publish(tpc, val, retain=True)
+            for k in ("light", "light2"):
+                blk = params.get(k)
+                if isinstance(blk, dict):
+                    session.light_state[k] = blk
+                    refreshed = normalize_status(
+                        session.device_id, {"data": {k: blk}},
+                        light_cache=session.light_state,
+                    )
+                    for tpc, val in refreshed.items():
                         self.mqtt_client.publish(tpc, val, retain=True)
 
     async def handle_client(
@@ -355,6 +366,12 @@ class MITMProxy:
                                                     for tpc, val in fan_extras_topics(
                                                             sess.device_id, k, params[k]).items():
                                                         self.mqtt_client.publish(tpc, val, retain=True)
+                                    if "light" in keypath or "light2" in keypath:
+                                        sess = nonlocal_session[0]
+                                        if sess is not None:
+                                            for k in ("light", "light2"):
+                                                if k in keypath and isinstance(params.get(k), dict):
+                                                    sess.light_state[k] = params[k]
                         except Exception as e:
                             logger.debug("relay_down parse error (non-fatal): %s", e)
                             buf_down = b""
@@ -462,7 +479,11 @@ def _process_publish(session: ProxySession, pkt, mqtt_client: mqtt.Client,
                             session.device_id, sorted(present))
                 session._outlet_discovery_pruned = True
 
-    normalized = normalize_status(session.device_id, data)
+    normalized = normalize_status(
+        session.device_id, data,
+        light_cache=getattr(session, "light_state", None),
+        fan_cache=getattr(session, "fan_state", None),
+    )
     for norm_topic, value in normalized.items():
         mqtt_client.publish(norm_topic, value, retain=True)
 

--- a/spiderbridge/app/proxy/mitm_proxy.py
+++ b/spiderbridge/app/proxy/mitm_proxy.py
@@ -12,7 +12,7 @@ from .mqtt_parser import (
     parse_packets, build_publish,
     MQTT_PUBLISH, MQTT_CONNECT, MQTT_SUBSCRIBE,
 )
-from .normalizer import normalize_status
+from .normalizer import normalize_status, fan_extras_topics
 from ha.discovery import (
     publish_soil_sensor_discovery as _publish_soil_sensor_discovery,
     unpublish_outlet_discovery as _unpublish_outlet_discovery,
@@ -51,6 +51,8 @@ class ProxySession:
         # Static discovery publishes outlets 1..10 unconditionally; once the
         # controller reports its actual outlet set we unpublish the rest.
         self._outlet_discovery_pruned: bool = False
+        # Full last-known fan/blower blocks for app-parity write paths.
+        self.fan_state: Dict[str, dict] = {}
 
     def set_upstream(self, writer: asyncio.StreamWriter) -> None:
         self._upstream_writer = writer
@@ -181,9 +183,17 @@ class MITMProxy:
 
         payload = translate_command(field, value, session.mac, session.uid, outlet_num,
                                     device_state=session.device_state, subfield=subfield,
-                                    last_nonzero_level=session.last_nonzero_level)
+                                    last_nonzero_level=session.last_nonzero_level,
+                                    fan_state=session.fan_state)
         if payload:
             await session.inject(payload)
+            params = payload.get("params", {})
+            for k in ("fan", "blower"):
+                blk = params.get(k)
+                if isinstance(blk, dict):
+                    session.fan_state[k] = blk
+                    for tpc, val in fan_extras_topics(session.device_id, k, blk).items():
+                        self.mqtt_client.publish(tpc, val, retain=True)
 
     async def handle_client(
         self,
@@ -337,6 +347,14 @@ class MITMProxy:
                                             keypath,
                                             json.dumps(params, separators=(',', ':')),
                                         )
+                                        sess = nonlocal_session[0]
+                                        if sess is not None:
+                                            for k in ("fan", "blower"):
+                                                if k in keypath and isinstance(params.get(k), dict):
+                                                    sess.fan_state[k] = params[k]
+                                                    for tpc, val in fan_extras_topics(
+                                                            sess.device_id, k, params[k]).items():
+                                                        self.mqtt_client.publish(tpc, val, retain=True)
                         except Exception as e:
                             logger.debug("relay_down parse error (non-fatal): %s", e)
                             buf_down = b""

--- a/spiderbridge/app/proxy/mitm_proxy.py
+++ b/spiderbridge/app/proxy/mitm_proxy.py
@@ -13,13 +13,12 @@ from .mqtt_parser import (
     parse_packets, build_publish,
     MQTT_PUBLISH, MQTT_CONNECT, MQTT_SUBSCRIBE,
 )
-from .normalizer import normalize_status, fan_extras_topics
+from .normalizer import normalize_status, fan_extras_topics, light_extras_topics
 from ha.discovery import (
     publish_soil_sensor_discovery as _publish_soil_sensor_discovery,
     unpublish_outlet_discovery as _unpublish_outlet_discovery,
 )
 from .command_handler import translate_command
-
 from .config import HA_OPTIONS_PATH, HA_DEVICES_PATH
 
 logger = logging.getLogger(__name__)
@@ -47,13 +46,22 @@ class ProxySession:
         self.last_nonzero_level: Dict[str, int] = {}  # module → last brightness > 0
         # SF protocol topic-prefix learned from observed cloud→device traffic.
         # Defaults to "CB" (Control Box) but PS5/PS10/LC may use a different
-        # value; using the wrong prefix means our injects are silently ignored.
+        # value; using the wrong prefix means our injects are silently
+        # ignored by the controller that subscribes elsewhere.
         self.down_topic_prefix: str = "CB"
         # Static discovery publishes outlets 1..10 unconditionally; once the
         # controller reports its actual outlet set we unpublish the rest.
         self._outlet_discovery_pruned: bool = False
         # Full last-known fan/blower blocks for app-parity write paths.
+        # getDevSta carries only minimal state ({on, level}); cloud
+        # setConfigField traffic carries the schedule/cycle/speeds we
+        # need to merge against on HA writes.
         self.fan_state: Dict[str, dict] = {}
+        # Same idea for light: getDevSta on some firmwares omits
+        # modeType, so we cache it from observed setConfigField traffic
+        # and from our own injects. Used by the normalizer as a fallback
+        # so the HA effect dropdown stays consistent with what the
+        # controller is actually doing.
         self.light_state: Dict[str, dict] = {}
 
     def set_upstream(self, writer: asyncio.StreamWriter) -> None:
@@ -149,6 +157,10 @@ class MITMProxy:
         return None
 
     def _save_config(self) -> None:
+        """Persist current in-memory config. Under HA OS the addon writes
+        only the devices list to /data/devices.yaml (the rest of the addon
+        config is read-only options). Standalone falls back to the full
+        config.yaml at the configured path."""
         if Path(HA_OPTIONS_PATH).exists():
             try:
                 with open(HA_DEVICES_PATH, "w") as f:
@@ -165,7 +177,9 @@ class MITMProxy:
                 logger.error("Fehler beim Speichern von config.yaml: %s", e)
 
     async def poll_session_config(self, sess: ProxySession) -> None:
-        """One round of getConfigField for all 4 modules on one session."""
+        """Inject one round of getConfigField for light/light2/fan/blower
+        into a single session. Called on session connect (immediate poll)
+        and periodically by config_poll_loop."""
         for keypath in (["device", "light"], ["device", "light2"],
                         ["device", "fan"], ["device", "blower"]):
             try:
@@ -177,16 +191,18 @@ class MITMProxy:
                     "uid": sess.uid,
                 })
             except Exception as e:
-                logger.debug("config poll inject failed for %s: %s", keypath, e)
+                logger.debug("config poll inject failed for %s: %s",
+                             keypath, e)
+            # Space out so we don't flood the controller in one burst
             await asyncio.sleep(0.5)
 
     async def config_poll_loop(self) -> None:
-        """Periodic ticker. Sessions also get an immediate one-shot poll on
-        connect (handle_client) so HA caches refresh straight after
-        restart/reconnect instead of waiting for the first interval tick.
+        """Periodically poll every active controller session. Each session
+        also gets an immediate one-shot poll on connect (handle_client),
+        so this loop only owns the recurring tick.
 
         Interval is configurable via proxy.config_poll_interval_sec
-        (default 600 = 10 minutes; 0 disables)."""
+        (default 600 = 10 minutes). Set to 0 to disable."""
         interval = int(self.config.get("proxy", {}).get("config_poll_interval_sec", 600))
         if interval <= 0:
             logger.info("Config poll disabled (interval=%s)", interval)
@@ -226,9 +242,13 @@ class MITMProxy:
         payload = translate_command(field, value, session.mac, session.uid, outlet_num,
                                     device_state=session.device_state, subfield=subfield,
                                     last_nonzero_level=session.last_nonzero_level,
-                                    fan_state=session.fan_state)
+                                    fan_state=session.fan_state,
+                                    light_state=session.light_state)
         if payload:
             await session.inject(payload)
+            # Optimistic update: write the fan/blower fields to the cache and
+            # publish per-field state topics so the new HA entities reflect
+            # the change without waiting for the next observed cloud echo.
             params = payload.get("params", {})
             for k in ("fan", "blower"):
                 blk = params.get(k)
@@ -236,6 +256,10 @@ class MITMProxy:
                     session.fan_state[k] = blk
                     for tpc, val in fan_extras_topics(session.device_id, k, blk).items():
                         self.mqtt_client.publish(tpc, val, retain=True)
+            # Same for light — and refresh the main state/light JSON so
+            # the HA effect dropdown reflects the new mode immediately
+            # rather than waiting for the next getDevSta (which on some
+            # firmwares does not even carry modeType).
             for k in ("light", "light2"):
                 blk = params.get(k)
                 if isinstance(blk, dict):
@@ -284,8 +308,11 @@ class MITMProxy:
                 s.publish_availability("online")
                 logger.info("Session erstellt: device_id=%s mac=%s", s.device_id, s.mac)
                 # Immediate one-shot config poll so HA caches refresh on
-                # restart/reconnect rather than waiting for the next tick.
+                # restart/reconnect rather than waiting for the next 10-min
+                # tick. Detached so the connect path doesn't block on it.
                 async def _initial_poll():
+                    # Small delay so the controller has finished its CONNECT
+                    # handshake before we start firing extra requests at it.
                     await asyncio.sleep(3)
                     await self.poll_session_config(s)
                 asyncio.create_task(_initial_poll())
@@ -345,14 +372,14 @@ class MITMProxy:
                         pass
 
             async def relay_down():
-                # Forward server→device traffic unchanged. Earlier we mutated
-                # setConfigField bodies here to keep HA's last command sticky
-                # against SF cloud corrections, but that fought legitimate
-                # app/cloud commands and made the lamp uncontrollable except
-                # from bluetooth-paired sessions. Now the path is read-only
-                # and only learns: per-outlet config blocks for cache replay,
-                # and the cloud's DOWN topic prefix so injects target the
-                # same one the controller actually subscribes to.
+                # Forward server→device traffic unchanged. Earlier we parsed
+                # packets here and mutated setConfigField bodies to keep HA's
+                # last command sticky against the SF cloud's corrections, but
+                # that fought legitimate app/cloud commands and made the lamp
+                # uncontrollable except from bluetooth-paired sessions.
+                # Diagnostic-only parsing here logs outlet-related commands
+                # from the SF cloud/app so we can compare what the official
+                # app sends vs what we send for PS5/PS10 outlet control.
                 buf_down = b""
                 try:
                     while True:
@@ -362,6 +389,7 @@ class MITMProxy:
                             break
                         if not data:
                             break
+                        # Forward bytes unchanged FIRST, then try to parse for logging
                         try:
                             client_writer.write(data)
                             await client_writer.drain()
@@ -373,6 +401,9 @@ class MITMProxy:
                             for p in packets:
                                 if (p.packet_type == MQTT_PUBLISH and p.topic
                                         and "/API/DOWN/" in p.topic and p.message):
+                                    # Learn the cloud's DOWN topic prefix so our
+                                    # injects target the same one (PS5/PS10 may
+                                    # not be CB).
                                     sess = nonlocal_session[0]
                                     if sess is not None:
                                         topic_parts = p.topic.split("/")
@@ -399,6 +430,11 @@ class MITMProxy:
                                             p.topic, keypath,
                                             json.dumps(params, separators=(',', ':')),
                                         )
+                                    # Fan feature-parity capture: log every
+                                    # cloud-side setConfigField for fan/blower
+                                    # at INFO level on this branch so we can
+                                    # reverse-engineer the SF App's fan
+                                    # settings screen field-by-field.
                                     if "fan" in keypath or "blower" in keypath:
                                         logger.info(
                                             "[FAN-CAPTURE] keyPath=%s params=%s",
@@ -419,7 +455,15 @@ class MITMProxy:
                                             for k in ("light", "light2"):
                                                 if k in keypath and isinstance(params.get(k), dict):
                                                     sess.light_state[k] = params[k]
+                                                    # Also push the per-field
+                                                    # extras so HA settings
+                                                    # entities populate even
+                                                    # without a getDevSta echo.
+                                                    for tpc, val in light_extras_topics(
+                                                            sess.device_id, k, params[k]).items():
+                                                        self.mqtt_client.publish(tpc, val, retain=True)
                         except Exception as e:
+                            # Never let logging break the relay
                             logger.debug("relay_down parse error (non-fatal): %s", e)
                             buf_down = b""
                 finally:
@@ -479,6 +523,10 @@ def _process_publish(session: ProxySession, pkt, mqtt_client: mqtt.Client,
     except Exception:
         return
     method = data.get("method")
+    # Accept any UP message that carries a data block — getDevSta is the
+    # main one, but getConfigField responses (when the controller honors
+    # them) come through here too. Setup-Acks without payload data fall
+    # through harmlessly because their "data" dict has no module blocks.
     if method not in ("getDevSta", "getConfigField"):
         return
     if method == "getConfigField":
@@ -499,7 +547,8 @@ def _process_publish(session: ProxySession, pkt, mqtt_client: mqtt.Client,
             # (modeType, schedule, etc) we need to keep.
             session.device_state.setdefault(module, {}).update(d[module])
     # Also feed light/fan caches from rich UP messages (getConfigField
-    # responses, full setConfigField echoes).
+    # responses, full setConfigField echoes). Same merge semantics so
+    # minimal getDevSta echoes don't clobber the cached schedule/cycle.
     for module in ("light", "light2"):
         if module in d and isinstance(d[module], dict):
             session.light_state.setdefault(module, {}).update(d[module])

--- a/spiderbridge/app/proxy/mitm_proxy.py
+++ b/spiderbridge/app/proxy/mitm_proxy.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import logging
 import ssl
+import time
 from pathlib import Path
 from typing import Dict, Optional
 
@@ -162,6 +163,42 @@ class MITMProxy:
                 logger.info("config.yaml aktualisiert.")
             except Exception as e:
                 logger.error("Fehler beim Speichern von config.yaml: %s", e)
+
+    async def config_poll_loop(self) -> None:
+        """Periodically inject getConfigField requests into every active
+        controller session so HA caches stay fresh even when the user only
+        touches the SF App. Interval is configurable via
+        proxy.config_poll_interval_sec (default 600 = 10 minutes; 0 disables)."""
+        interval = int(self.config.get("proxy", {}).get("config_poll_interval_sec", 600))
+        if interval <= 0:
+            logger.info("Config poll disabled (interval=%s)", interval)
+            return
+        logger.info("Config poll loop started, interval=%ds", interval)
+        await asyncio.sleep(min(60, interval))
+        while True:
+            try:
+                for sess in list(self._sessions.values()):
+                    for keypath in (["device", "light"], ["device", "light2"],
+                                    ["device", "fan"], ["device", "blower"]):
+                        try:
+                            await sess.inject({
+                                "method": "getConfigField",
+                                "pid": sess.mac,
+                                "params": {"keyPath": keypath},
+                                "msgId": str(int(time.time() * 1000)),
+                                "uid": sess.uid,
+                            })
+                        except Exception as e:
+                            logger.debug("config poll inject failed for %s: %s",
+                                         keypath, e)
+                        await asyncio.sleep(0.5)
+                await asyncio.sleep(interval)
+            except asyncio.CancelledError:
+                logger.info("Config poll loop stopped")
+                break
+            except Exception as e:
+                logger.warning("Config poll loop error: %s", e)
+                await asyncio.sleep(30)
 
     async def handle_command(self, topic: str, value: str) -> None:
         """Handle an incoming HA command from local Mosquitto."""
@@ -432,8 +469,11 @@ def _process_publish(session: ProxySession, pkt, mqtt_client: mqtt.Client,
     except Exception:
         return
     method = data.get("method")
-    if method != "getDevSta":
+    if method not in ("getDevSta", "getConfigField"):
         return
+    if method == "getConfigField":
+        logger.info("[CONFIG-RESP] data=%s",
+                    json.dumps(data.get("data", {}), separators=(',', ':'))[:500])
 
     # Keep UID up to date from controller messages
     uid = data.get("uid", "")
@@ -444,7 +484,18 @@ def _process_publish(session: ProxySession, pkt, mqtt_client: mqtt.Client,
     d = data.get("data", {})
     for module in ("light", "light2", "blower", "fan", "heater", "humidifier", "dehumidifier"):
         if module in d:
-            session.device_state[module] = d[module]
+            # Merge instead of replace — getDevSta on some firmwares carries
+            # only {on, level} for light/fan, which would wipe cached fields
+            # (modeType, schedule, etc) we need to keep.
+            session.device_state.setdefault(module, {}).update(d[module])
+    # Also feed light/fan caches from rich UP messages (getConfigField
+    # responses, full setConfigField echoes).
+    for module in ("light", "light2"):
+        if module in d and isinstance(d[module], dict):
+            session.light_state.setdefault(module, {}).update(d[module])
+    for module in ("fan", "blower"):
+        if module in d and isinstance(d[module], dict):
+            session.fan_state.setdefault(module, {}).update(d[module])
 
     # Remember last non-zero brightness so OFF→ON restores the previous level
     for module in ("light", "light2"):

--- a/spiderbridge/app/proxy/normalizer.py
+++ b/spiderbridge/app/proxy/normalizer.py
@@ -89,7 +89,9 @@ def fan_extras_topics(device_id: str, prefix: str, block: Dict[str, Any]) -> Dic
     return out
 
 
-def normalize_status(device_id: str, data: Dict[str, Any]) -> Dict[str, str]:
+def normalize_status(device_id: str, data: Dict[str, Any],
+                     light_cache: Dict[str, dict] | None = None,
+                     fan_cache: Dict[str, dict] | None = None) -> Dict[str, str]:
     result: Dict[str, str] = {}
     d = data.get("data", data)
 
@@ -120,9 +122,16 @@ def normalize_status(device_id: str, data: Dict[str, Any]) -> Dict[str, str]:
             "effect": _LIGHT_MODES.get(lc_mode, str(lc_mode)),
         })
 
+    # Light blocks: getDevSta only carries {on, level} for some firmwares —
+    # no modeType. Falling back to a hard-coded default would flip HA's
+    # effect dropdown to the wrong mode whenever the controller sends a
+    # status update. Prefer the cached modeType from observed setConfigField
+    # traffic instead.
+    lc = light_cache or {}
+
     light = d.get("light", {})
     if light:
-        mode = light.get("modeType", 1)
+        mode = light.get("modeType", lc.get("light", {}).get("modeType", 0))
         result[f"spiderfarmer/{device_id}/state/light"] = json.dumps({
             "state": _on_off(light.get("on", light.get("mOnOff", 0))),
             "brightness": light.get("level", light.get("mLevel", 0)),
@@ -131,7 +140,7 @@ def normalize_status(device_id: str, data: Dict[str, Any]) -> Dict[str, str]:
 
     light2 = d.get("light2", {})
     if light2:
-        mode2 = light2.get("modeType", 1)
+        mode2 = light2.get("modeType", lc.get("light2", {}).get("modeType", 0))
         result[f"spiderfarmer/{device_id}/state/light2"] = json.dumps({
             "state": _on_off(light2.get("on", light2.get("mOnOff", 0))),
             "brightness": light2.get("level", light2.get("mLevel", 0)),

--- a/spiderbridge/app/proxy/normalizer.py
+++ b/spiderbridge/app/proxy/normalizer.py
@@ -13,9 +13,80 @@ _SENSOR_FIELD_MAP = [
     ("ECSoil", "ec_soil"),
 ]
 
+# modeType values for the fan block — confirmed from cloud setConfigField
+# captures while clicking through every mode in the SF App. The five Umwelt-
+# variants share modeType space with Manuell/Zeitfenster/Zyklus rather than
+# living in a separate Betriebsmodus field.
+_FAN_MODES = {
+    0: "Manual",
+    1: "Schedule",
+    2: "Cycle",
+    3: "Environment: Temperature only",
+    4: "Environment: Humidity only",
+    7: "Environment: Prioritize temperature",
+    8: "Environment: Prioritize humidity",
+    13: "Environment: Temperature & humidity",
+}
+
 
 def _on_off(val) -> str:
     return "ON" if val in (1, True, "1", "true", "on") else "OFF"
+
+
+def _seconds_to_hhmm(seconds) -> str:
+    try:
+        s = int(seconds) % 86400
+    except (TypeError, ValueError):
+        return "00:00"
+    return f"{s // 3600:02d}:{(s % 3600) // 60:02d}"
+
+
+def fan_extras_topics(device_id: str, prefix: str, block: Dict[str, Any]) -> Dict[str, str]:
+    """Per-field state topics for a fan/blower block. Used by normalize_status
+    when getDevSta arrives and by relay_down after observing a cloud
+    setConfigField, so the new HA entities (preset_mode, schedule, cycle,
+    speeds) get populated immediately."""
+    out: Dict[str, str] = {}
+    if not isinstance(block, dict):
+        return out
+    base = f"spiderfarmer/{device_id}/state/{prefix}"
+    if "modeType" in block:
+        mt = block["modeType"]
+        out[f"{base}/mode_label"] = _FAN_MODES.get(mt, str(mt))
+    if "maxSpeed" in block:
+        out[f"{base}/schedule_speed"] = str(block["maxSpeed"])
+    if "minSpeed" in block:
+        out[f"{base}/standby_speed"] = str(block["minSpeed"])
+    if "shakeLevel" in block:
+        out[f"{base}/oscillation_level"] = str(block["shakeLevel"])
+    if "natural" in block:
+        out[f"{base}/natural_wind"] = _on_off(block["natural"])
+    # Schedule-Modus (Zeitfenster) — timePeriod[0]
+    periods = block.get("timePeriod") or []
+    if isinstance(periods, list) and periods:
+        tp = periods[0] if isinstance(periods[0], dict) else {}
+        if "startTime" in tp:
+            out[f"{base}/schedule_start"] = _seconds_to_hhmm(tp["startTime"])
+        if "endTime" in tp:
+            out[f"{base}/schedule_end"] = _seconds_to_hhmm(tp["endTime"])
+    # Zyklusmodus
+    ct = block.get("cycleTime")
+    if isinstance(ct, dict):
+        if "startTime" in ct:
+            out[f"{base}/cycle_start"] = _seconds_to_hhmm(ct["startTime"])
+        if "openDur" in ct:
+            try:
+                out[f"{base}/cycle_run_minutes"] = str(int(ct["openDur"]) // 60)
+            except (TypeError, ValueError):
+                pass
+        if "closeDur" in ct:
+            try:
+                out[f"{base}/cycle_off_minutes"] = str(int(ct["closeDur"]) // 60)
+            except (TypeError, ValueError):
+                pass
+        if "times" in ct:
+            out[f"{base}/cycle_times"] = str(ct["times"])
+    return out
 
 
 def normalize_status(device_id: str, data: Dict[str, Any]) -> Dict[str, str]:
@@ -72,6 +143,7 @@ def normalize_status(device_id: str, data: Dict[str, Any]) -> Dict[str, str]:
             "state": _on_off(blower.get("on", blower.get("mOnOff", 0))),
             "percentage": blower.get("level", blower.get("mLevel", 0)),
         })
+        result.update(fan_extras_topics(device_id, "blower", blower))
 
     # ── Fan (JSON state + oscillation) ────────────────────────────────────────
     fan = d.get("fan", {})
@@ -80,6 +152,7 @@ def normalize_status(device_id: str, data: Dict[str, Any]) -> Dict[str, str]:
             "state": _on_off(fan.get("on", fan.get("mOnOff", 0))),
             "percentage": fan.get("level", fan.get("mLevel", 0)),
         })
+        result.update(fan_extras_topics(device_id, "fan", fan))
 
     # ── Accessories ───────────────────────────────────────────────────────────
     for module in ("heater", "humidifier", "dehumidifier"):

--- a/spiderbridge/app/proxy/normalizer.py
+++ b/spiderbridge/app/proxy/normalizer.py
@@ -41,6 +41,56 @@ def _seconds_to_hhmm(seconds) -> str:
     return f"{s // 3600:02d}:{(s % 3600) // 60:02d}"
 
 
+def light_extras_topics(device_id: str, prefix: str, block: Dict[str, Any]) -> Dict[str, str]:
+    """Per-field state topics for a light/light2 block. Used both by
+    normalize_status when getDevSta arrives and by relay_down / handle_command
+    after a setConfigField is observed/sent so the new HA entities populate
+    immediately. Mirror of fan_extras_topics, just for the light schema."""
+    out: Dict[str, str] = {}
+    if not isinstance(block, dict):
+        return out
+    base = f"spiderfarmer/{device_id}/state/{prefix}"
+    if "darkTemp" in block:
+        out[f"{base}/dim_threshold"] = str(block["darkTemp"])
+    if "offTemp" in block:
+        out[f"{base}/off_threshold"] = str(block["offTemp"])
+    # Schedule (Zeitfenstermodus) — timePeriod[0]
+    periods = block.get("timePeriod") or []
+    if isinstance(periods, list) and periods:
+        tp = periods[0] if isinstance(periods[0], dict) else {}
+        if "brightness" in tp:
+            out[f"{base}/schedule_brightness"] = str(tp["brightness"])
+        if "startTime" in tp:
+            out[f"{base}/schedule_start"] = _seconds_to_hhmm(tp["startTime"])
+        if "endTime" in tp:
+            out[f"{base}/schedule_end"] = _seconds_to_hhmm(tp["endTime"])
+        if "fadeTime" in tp:
+            try:
+                out[f"{base}/fade_minutes"] = str(int(tp["fadeTime"]) // 60)
+            except (TypeError, ValueError):
+                pass
+    # PPFD-Mode — own schedule + brightness limits
+    ppfd_periods = block.get("ppfdPeriod") or []
+    if isinstance(ppfd_periods, list) and ppfd_periods:
+        pp = ppfd_periods[0] if isinstance(ppfd_periods[0], dict) else {}
+        if "brightness" in pp:
+            out[f"{base}/ppfd_target"] = str(pp["brightness"])
+        if "startTime" in pp:
+            out[f"{base}/ppfd_start"] = _seconds_to_hhmm(pp["startTime"])
+        if "endTime" in pp:
+            out[f"{base}/ppfd_end"] = _seconds_to_hhmm(pp["endTime"])
+        if "fadeTime" in pp:
+            try:
+                out[f"{base}/ppfd_fade_minutes"] = str(int(pp["fadeTime"]) // 60)
+            except (TypeError, ValueError):
+                pass
+    if "ppfdMinBrightness" in block:
+        out[f"{base}/ppfd_min"] = str(block["ppfdMinBrightness"])
+    if "ppfdMaxBrightness" in block:
+        out[f"{base}/ppfd_max"] = str(block["ppfdMaxBrightness"])
+    return out
+
+
 def fan_extras_topics(device_id: str, prefix: str, block: Dict[str, Any]) -> Dict[str, str]:
     """Per-field state topics for a fan/blower block. Used by normalize_status
     when getDevSta arrives and by relay_down after observing a cloud
@@ -137,6 +187,11 @@ def normalize_status(device_id: str, data: Dict[str, Any],
             "brightness": light.get("level", light.get("mLevel", 0)),
             "effect": _LIGHT_MODES.get(mode, str(mode)),
         })
+        # Merge cached schedule/ppfd/temp fields into the block we hand to
+        # light_extras_topics — getDevSta on its own only carries on/level
+        # and would yield empty entities until the next setConfigField.
+        merged = {**lc.get("light", {}), **light}
+        result.update(light_extras_topics(device_id, "light", merged))
 
     light2 = d.get("light2", {})
     if light2:
@@ -146,6 +201,8 @@ def normalize_status(device_id: str, data: Dict[str, Any],
             "brightness": light2.get("level", light2.get("mLevel", 0)),
             "effect": _LIGHT_MODES.get(mode2, str(mode2)),
         })
+        merged2 = {**lc.get("light2", {}), **light2}
+        result.update(light_extras_topics(device_id, "light2", merged2))
 
     # ── Blower (JSON state) ───────────────────────────────────────────────────
     blower = d.get("blower", {})

--- a/spiderbridge/app/proxy/normalizer.py
+++ b/spiderbridge/app/proxy/normalizer.py
@@ -103,7 +103,9 @@ def normalize_status(device_id: str, data: Dict[str, Any]) -> Dict[str, str]:
     # Both modeType 0 (Manual) and 1 (Timer) map to the same UI label so the
     # effect dropdown in HA shows a known value regardless of which the
     # controller currently reports.
-    _LIGHT_MODES = {0: "Modus: Manual / Timer", 1: "Modus: Manual / Timer", 12: "Modus: PPFD"}
+    # modeType values confirmed against the SF App.
+    # 0 = Manual, 1 = Schedule (Zeitfenstermodus), 12 = PPFD.
+    _LIGHT_MODES = {0: "Manual", 1: "Schedule", 12: "PPFD"}
 
     # Standalone Light Controller (LC) reports light state flat at the top
     # level — `data.brightness` + `data.mode` instead of nested under

--- a/spiderbridge/app/tests/test_command_handler.py
+++ b/spiderbridge/app/tests/test_command_handler.py
@@ -225,3 +225,101 @@ def test_payload_includes_pid_uid_and_msg_id():
     # msgId is a string of millisecond timestamp
     assert isinstance(r["msgId"], str)
     assert int(r["msgId"]) > 0
+
+
+# ── Fan app-parity (preset_mode + subfield writes) ──────────────────────────
+
+def test_fan_preset_mode_maps_label_to_modeType():
+    cached = {"fan": {"modeType": 0, "mOnOff": 1, "mLevel": 3,
+                      "shakeLevel": 0, "natural": 0,
+                      "timePeriod": [{"weekmask": 127}],
+                      "cycleTime": {"weekmask": 127}}}
+    r = translate_command("fan", "Environment: Prioritize temperature",
+                          "AABBCC", "uid1",
+                          subfield="preset_mode", fan_state=cached)
+    assert r["params"]["fan"]["modeType"] == 7
+    # other fields preserved
+    assert r["params"]["fan"]["mLevel"] == 3
+    assert r["params"]["fan"]["shakeLevel"] == 0
+
+
+def test_fan_preset_mode_unknown_label_returns_none():
+    r = translate_command("fan", "Bogus Mode", "AABBCC", "uid1",
+                          subfield="preset_mode", fan_state={})
+    assert r is None
+
+
+def test_fan_schedule_start_parses_hhmm():
+    r = translate_command("fan", "07:30", "AABBCC", "uid1",
+                          subfield="schedule_start", fan_state={})
+    assert r["params"]["fan"]["timePeriod"][0]["startTime"] == 7 * 3600 + 30 * 60
+
+
+def test_fan_cycle_run_minutes_to_seconds():
+    r = translate_command("fan", "10", "AABBCC", "uid1",
+                          subfield="cycle_run_minutes", fan_state={})
+    assert r["params"]["fan"]["cycleTime"]["openDur"] == 600
+
+
+def test_fan_cycle_times_clamped_to_100():
+    r = translate_command("fan", "9999", "AABBCC", "uid1",
+                          subfield="cycle_times", fan_state={})
+    assert r["params"]["fan"]["cycleTime"]["times"] == 100
+
+
+def test_fan_schedule_speed_clamped_to_10():
+    r = translate_command("fan", "15", "AABBCC", "uid1",
+                          subfield="schedule_speed", fan_state={})
+    assert r["params"]["fan"]["maxSpeed"] == 10
+
+
+def test_fan_standby_speed_zero_means_aus():
+    r = translate_command("fan", "0", "AABBCC", "uid1",
+                          subfield="standby_speed", fan_state={})
+    assert r["params"]["fan"]["minSpeed"] == 0
+
+
+def test_fan_oscillation_level_writes_shake_level():
+    r = translate_command("fan", "7", "AABBCC", "uid1",
+                          subfield="oscillation_level", fan_state={})
+    assert r["params"]["fan"]["shakeLevel"] == 7
+
+
+def test_fan_natural_wind_on_off():
+    on = translate_command("fan", "ON", "AABBCC", "uid1",
+                           subfield="natural_wind", fan_state={})
+    off = translate_command("fan", "OFF", "AABBCC", "uid1",
+                            subfield="natural_wind", fan_state={})
+    assert on["params"]["fan"]["natural"] == 1
+    assert off["params"]["fan"]["natural"] == 0
+
+
+def test_fan_subfield_targets_blower_keypath_when_field_is_blower():
+    r = translate_command("blower", "5", "AABBCC", "uid1",
+                          subfield="schedule_speed", fan_state={})
+    assert r["params"]["keyPath"] == ["device", "blower"]
+    assert "blower" in r["params"]
+    assert r["params"]["blower"]["maxSpeed"] == 5
+
+
+def test_fan_subfield_preserves_cached_block_other_fields():
+    cached = {"fan": {
+        "modeType": 2, "mOnOff": 1, "mLevel": 3,
+        "shakeLevel": 6, "natural": 1,
+        "minSpeed": 1, "maxSpeed": 5,
+        "timePeriod": [{"enabled": 1, "weekmask": 127,
+                        "startTime": 3600, "endTime": 7200}],
+        "cycleTime": {"weekmask": 127, "startTime": 10800,
+                      "openDur": 600, "closeDur": 1200, "times": 5},
+    }}
+    r = translate_command("fan", "20", "AABBCC", "uid1",
+                          subfield="cycle_run_minutes", fan_state=cached)
+    out = r["params"]["fan"]
+    # Changed
+    assert out["cycleTime"]["openDur"] == 1200
+    # Untouched
+    assert out["cycleTime"]["closeDur"] == 1200
+    assert out["cycleTime"]["times"] == 5
+    assert out["modeType"] == 2
+    assert out["maxSpeed"] == 5
+    assert out["natural"] == 1

--- a/spiderbridge/app/tests/test_command_handler.py
+++ b/spiderbridge/app/tests/test_command_handler.py
@@ -327,6 +327,145 @@ def test_fan_subfield_targets_blower_keypath_when_field_is_blower():
     assert r["params"]["blower"]["maxSpeed"] == 5
 
 
+# ── Light app-parity (subfield writes) ─────────────────────────────────────
+
+def _light_block(**overrides):
+    """Realistic cached light block as observed from cloud setConfigField."""
+    blk = {
+        "modeType": 1, "lastAutoModeType": 0, "mOnOff": 1, "mLevel": 65,
+        "darkTemp": 0, "offTemp": 0,
+        "timePeriod": [{"enabled": 1, "weekmask": 127,
+                        "startTime": 21600, "endTime": 72000,
+                        "brightness": 65, "fadeTime": 900}],
+        "ppfdPeriod": [{"enabled": 0, "weekmask": 127,
+                        "startTime": 0, "endTime": 0,
+                        "brightness": 20, "fadeTime": 0}],
+        "ppfdMinBrightness": 0, "ppfdMaxBrightness": 100,
+    }
+    blk.update(overrides)
+    return {"light": blk}
+
+
+def test_light_schedule_brightness_subfield():
+    cached = _light_block()
+    r = translate_command("light", "80", "AABBCC", "uid1",
+                          subfield="schedule_brightness", light_state=cached)
+    assert r["params"]["keyPath"] == ["device", "light"]
+    assert r["params"]["light"]["timePeriod"][0]["brightness"] == 80
+
+
+def test_light_schedule_brightness_clamped():
+    r = translate_command("light", "999", "AABBCC", "uid1",
+                          subfield="schedule_brightness", light_state=_light_block())
+    assert r["params"]["light"]["timePeriod"][0]["brightness"] == 100
+
+
+def test_light_schedule_start_parses_hhmm():
+    r = translate_command("light", "06:30", "AABBCC", "uid1",
+                          subfield="schedule_start", light_state=_light_block())
+    assert r["params"]["light"]["timePeriod"][0]["startTime"] == 6 * 3600 + 30 * 60
+
+
+def test_light_schedule_end_parses_hhmm():
+    r = translate_command("light", "20:00", "AABBCC", "uid1",
+                          subfield="schedule_end", light_state=_light_block())
+    assert r["params"]["light"]["timePeriod"][0]["endTime"] == 20 * 3600
+
+
+def test_light_fade_minutes_to_seconds():
+    r = translate_command("light", "15", "AABBCC", "uid1",
+                          subfield="fade_minutes", light_state=_light_block())
+    assert r["params"]["light"]["timePeriod"][0]["fadeTime"] == 900
+
+
+def test_light_dim_threshold_writes_dark_temp():
+    r = translate_command("light", "27.5", "AABBCC", "uid1",
+                          subfield="dim_threshold", light_state=_light_block())
+    assert r["params"]["light"]["darkTemp"] == 27.5
+
+
+def test_light_off_threshold_writes_off_temp():
+    r = translate_command("light", "30", "AABBCC", "uid1",
+                          subfield="off_threshold", light_state=_light_block())
+    assert r["params"]["light"]["offTemp"] == 30.0
+
+
+def test_light_ppfd_target_writes_ppfd_period_brightness():
+    r = translate_command("light", "650", "AABBCC", "uid1",
+                          subfield="ppfd_target", light_state=_light_block())
+    assert r["params"]["light"]["ppfdPeriod"][0]["brightness"] == 650
+
+
+def test_light_ppfd_target_clamped_to_1000():
+    r = translate_command("light", "9999", "AABBCC", "uid1",
+                          subfield="ppfd_target", light_state=_light_block())
+    assert r["params"]["light"]["ppfdPeriod"][0]["brightness"] == 1000
+
+
+def test_light_ppfd_min_max_clamped_to_100():
+    rmin = translate_command("light", "150", "AABBCC", "uid1",
+                             subfield="ppfd_min", light_state=_light_block())
+    rmax = translate_command("light", "200", "AABBCC", "uid1",
+                             subfield="ppfd_max", light_state=_light_block())
+    assert rmin["params"]["light"]["ppfdMinBrightness"] == 100
+    assert rmax["params"]["light"]["ppfdMaxBrightness"] == 100
+
+
+def test_light_ppfd_start_end_parses_hhmm():
+    rs = translate_command("light", "07:15", "AABBCC", "uid1",
+                           subfield="ppfd_start", light_state=_light_block())
+    re = translate_command("light", "19:45", "AABBCC", "uid1",
+                           subfield="ppfd_end", light_state=_light_block())
+    assert rs["params"]["light"]["ppfdPeriod"][0]["startTime"] == 7 * 3600 + 15 * 60
+    assert re["params"]["light"]["ppfdPeriod"][0]["endTime"] == 19 * 3600 + 45 * 60
+
+
+def test_light_ppfd_fade_minutes_to_seconds():
+    r = translate_command("light", "5", "AABBCC", "uid1",
+                          subfield="ppfd_fade_minutes", light_state=_light_block())
+    assert r["params"]["light"]["ppfdPeriod"][0]["fadeTime"] == 300
+
+
+def test_light_subfield_with_empty_cache_synthesizes_default_block():
+    # No cached block — translator must still produce a valid setConfigField.
+    # Otherwise the controller silently rejects partial writes.
+    r = translate_command("light", "07:00", "AABBCC", "uid1",
+                          subfield="schedule_start", light_state={})
+    assert r is not None
+    blk = r["params"]["light"]
+    assert blk["timePeriod"][0]["startTime"] == 7 * 3600
+    # Synthesized defaults present
+    assert "ppfdPeriod" in blk
+    assert "darkTemp" in blk
+
+
+def test_light_subfield_preserves_cached_block_other_fields():
+    cached = _light_block(modeType=12, mLevel=50)
+    r = translate_command("light", "55", "AABBCC", "uid1",
+                          subfield="ppfd_min", light_state=cached)
+    out = r["params"]["light"]
+    # Changed
+    assert out["ppfdMinBrightness"] == 55
+    # Untouched
+    assert out["modeType"] == 12
+    assert out["mLevel"] == 50
+    assert out["timePeriod"][0]["brightness"] == 65
+
+
+def test_light2_subfield_targets_light2_keypath():
+    r = translate_command("light2", "08:00", "AABBCC", "uid1",
+                          subfield="schedule_start",
+                          light_state={"light2": {"timePeriod": [{}]}})
+    assert r["params"]["keyPath"] == ["device", "light2"]
+    assert "light2" in r["params"]
+
+
+def test_light_invalid_numeric_subfield_returns_none():
+    r = translate_command("light", "abc", "AABBCC", "uid1",
+                          subfield="schedule_brightness", light_state=_light_block())
+    assert r is None
+
+
 def test_fan_subfield_preserves_cached_block_other_fields():
     cached = {"fan": {
         "modeType": 2, "mOnOff": 1, "mLevel": 3,

--- a/spiderbridge/app/tests/test_command_handler.py
+++ b/spiderbridge/app/tests/test_command_handler.py
@@ -23,7 +23,7 @@ def test_outlet_off():
 # ── Light / Light2 ──────────────────────────────────────────────────────────
 
 def test_light_full_json_payload_with_ppfd_mode():
-    val = json.dumps({"state": "ON", "brightness": 80, "effect": "Modus: PPFD"})
+    val = json.dumps({"state": "ON", "brightness": 80, "effect": "PPFD"})
     r = translate_command("light", val, "AABBCC", "uid1")
     assert r["params"]["keyPath"] == ["device", "light"]
     assert r["params"]["light"]["mOnOff"] == 1
@@ -32,14 +32,29 @@ def test_light_full_json_payload_with_ppfd_mode():
 
 
 def test_light2_full_json_payload_with_manual_mode():
-    # "Modus: Manual / Timer" effect maps to modeType 0 (Manual). Sending
-    # modeType 1 (Timer) makes the controller follow the schedule and ignore
-    # direct mOnOff/mLevel commands, which broke HA control of the lamp.
-    val = json.dumps({"state": "ON", "brightness": 50, "effect": "Modus: Manual / Timer"})
+    val = json.dumps({"state": "ON", "brightness": 50, "effect": "Manual"})
     r = translate_command("light2", val, "AABBCC", "uid1")
     assert r["params"]["keyPath"] == ["device", "light2"]
     assert r["params"]["light2"]["modeType"] == 0
     assert r["params"]["light2"]["mLevel"] == 50
+
+
+def test_light_schedule_mode_maps_to_modeType_1():
+    # "Schedule" effect must produce modeType=1 (Zeitfenstermodus); older
+    # code merged 0 and 1 under one label which made schedule-mode
+    # selection a no-op.
+    val = json.dumps({"state": "ON", "brightness": 70, "effect": "Schedule"})
+    r = translate_command("light", val, "AABBCC", "uid1")
+    assert r["params"]["light"]["modeType"] == 1
+
+
+def test_light_legacy_effect_label_still_resolves_to_manual():
+    # Old HA configs that have "Modus: Manual / Timer" stored as the effect
+    # should still work after the rename — the alias keeps them on
+    # modeType=0 instead of falling through to the default.
+    val = json.dumps({"state": "ON", "effect": "Modus: Manual / Timer"})
+    r = translate_command("light", val, "AABBCC", "uid1")
+    assert r["params"]["light"]["modeType"] == 0
 
 
 def test_light_default_mode_is_manual():

--- a/spiderbridge/app/tests/test_command_handler.py
+++ b/spiderbridge/app/tests/test_command_handler.py
@@ -273,6 +273,16 @@ def test_fan_schedule_speed_clamped_to_10():
     assert r["params"]["fan"]["maxSpeed"] == 10
 
 
+def test_fan_schedule_speed_also_writes_mlevel_for_manual_mode():
+    # Manual mode reads mLevel, Schedule/Cycle/Env modes read maxSpeed.
+    # The single HA "Speed" entity must change the fan regardless of
+    # which mode is currently active, so we set both.
+    r = translate_command("fan", "5", "AABBCC", "uid1",
+                          subfield="schedule_speed", fan_state={})
+    assert r["params"]["fan"]["maxSpeed"] == 5
+    assert r["params"]["fan"]["mLevel"] == 5
+
+
 def test_fan_standby_speed_zero_means_aus():
     r = translate_command("fan", "0", "AABBCC", "uid1",
                           subfield="standby_speed", fan_state={})

--- a/spiderbridge/app/tests/test_discovery.py
+++ b/spiderbridge/app/tests/test_discovery.py
@@ -125,17 +125,30 @@ def test_publish_discovery_uses_retain_for_every_message(mocker):
 
 
 def test_publish_discovery_device_info_consistent(mocker):
+    # Main entities live on the GGS controller; Fan Circulation settings
+    # entities live on three sub-devices (Schedule Mode, Cycle Mode, Speeds)
+    # linked back via via_device.
     client = mocker.MagicMock()
     publish_discovery_for_device(client, "ggs_1", CFG)
     pubs = _publish_calls(client)
 
     seen = {tuple(p["device"]["identifiers"]) for p in pubs.values()}
-    assert seen == {("spiderfarmer_ggs_1",)}
+    assert ("spiderfarmer_ggs_1",) in seen
+    sub_ids = {ids for ids in seen if ids != ("spiderfarmer_ggs_1",)}
+    assert sub_ids == {
+        ("spiderfarmer_ggs_1_fan_schedule",),
+        ("spiderfarmer_ggs_1_fan_cycle",),
+        ("spiderfarmer_ggs_1_fan_speeds",),
+    }
 
     for p in pubs.values():
+        ids = tuple(p["device"]["identifiers"])
         assert p["device"]["manufacturer"] == "Spider Farmer"
-        assert p["device"]["model"] == "GGS Controller"
-        assert p["device"]["name"] == "Test GGS"
+        if ids == ("spiderfarmer_ggs_1",):
+            assert p["device"]["model"] == "GGS Controller"
+            assert p["device"]["name"] == "Test GGS"
+        else:
+            assert p["device"]["via_device"] == "spiderfarmer_ggs_1"
 
 
 def test_unpublish_outlet_discovery_sends_empty_retained_payload(mocker):
@@ -170,3 +183,69 @@ def test_publish_soil_sensor_discovery_emits_three_entities(mocker):
     assert ec_topic in pubs
     assert "device_class" not in pubs[ec_topic]
     assert pubs[ec_topic]["unit_of_measurement"] == "mS/cm"
+
+
+def test_publish_discovery_emits_fan_preset_modes(mocker):
+    client = mocker.MagicMock()
+    publish_discovery_for_device(client, "ggs_1", CFG)
+    pubs = _publish_calls(client)
+
+    fan = pubs["homeassistant/fan/spiderfarmer_ggs_1_fan/config"]
+    assert fan["preset_mode_state_topic"] == "spiderfarmer/ggs_1/state/fan/mode_label"
+    assert fan["preset_mode_command_topic"] == "spiderfarmer/ggs_1/command/fan/preset_mode/set"
+    assert "Manual" in fan["preset_modes"]
+    assert "Schedule" in fan["preset_modes"]
+    assert "Cycle" in fan["preset_modes"]
+    assert "Environment: Prioritize temperature" in fan["preset_modes"]
+    assert len(fan["preset_modes"]) == 8
+
+
+def test_publish_discovery_emits_fan_extras(mocker):
+    client = mocker.MagicMock()
+    publish_discovery_for_device(client, "ggs_1", CFG)
+    topics = {call.args[0] for call in client.publish.call_args_list}
+
+    # Schedule Mode sub-device
+    assert "homeassistant/text/spiderfarmer_ggs_1_fan_schedule_start/config" in topics
+    assert "homeassistant/text/spiderfarmer_ggs_1_fan_schedule_end/config" in topics
+    # Cycle Mode sub-device
+    assert "homeassistant/text/spiderfarmer_ggs_1_fan_cycle_start/config" in topics
+    assert "homeassistant/number/spiderfarmer_ggs_1_fan_cycle_run_minutes/config" in topics
+    assert "homeassistant/number/spiderfarmer_ggs_1_fan_cycle_off_minutes/config" in topics
+    assert "homeassistant/number/spiderfarmer_ggs_1_fan_cycle_times/config" in topics
+    # Speeds sub-device
+    assert "homeassistant/number/spiderfarmer_ggs_1_fan_schedule_speed/config" in topics
+    assert "homeassistant/number/spiderfarmer_ggs_1_fan_standby_speed/config" in topics
+    assert "homeassistant/number/spiderfarmer_ggs_1_fan_oscillation_level/config" in topics
+    # Natural wind on main device (switch)
+    assert "homeassistant/switch/spiderfarmer_ggs_1_fan_natural_wind/config" in topics
+
+
+def test_fan_extras_grouped_into_sub_devices(mocker):
+    client = mocker.MagicMock()
+    publish_discovery_for_device(client, "ggs_1", CFG)
+    pubs = _publish_calls(client)
+
+    # Schedule fields → Schedule Mode sub-device
+    ss = pubs["homeassistant/text/spiderfarmer_ggs_1_fan_schedule_start/config"]
+    assert ss["device"]["identifiers"] == ["spiderfarmer_ggs_1_fan_schedule"]
+    assert ss["device"]["via_device"] == "spiderfarmer_ggs_1"
+
+    # Cycle fields → Cycle Mode sub-device
+    cr = pubs["homeassistant/number/spiderfarmer_ggs_1_fan_cycle_run_minutes/config"]
+    assert cr["device"]["identifiers"] == ["spiderfarmer_ggs_1_fan_cycle"]
+    assert cr["unit_of_measurement"] == "min"
+    assert cr["max"] == 1440
+
+    # Cycle times max 100 (controller cap)
+    ct = pubs["homeassistant/number/spiderfarmer_ggs_1_fan_cycle_times/config"]
+    assert ct["max"] == 100
+
+    # Speed fields → Speeds sub-device
+    sp = pubs["homeassistant/number/spiderfarmer_ggs_1_fan_schedule_speed/config"]
+    assert sp["device"]["identifiers"] == ["spiderfarmer_ggs_1_fan_speeds"]
+    assert sp["min"] == 1 and sp["max"] == 10
+
+    # Natural wind switch on main device
+    nw = pubs["homeassistant/switch/spiderfarmer_ggs_1_fan_natural_wind/config"]
+    assert nw["device"]["identifiers"] == ["spiderfarmer_ggs_1"]

--- a/spiderbridge/app/tests/test_discovery.py
+++ b/spiderbridge/app/tests/test_discovery.py
@@ -46,7 +46,7 @@ def test_publish_discovery_emits_lights_with_effect_list(mocker):
     assert light["schema"] == "json"
     assert light["brightness"] is True
     assert light["brightness_scale"] == 100
-    assert light["effect_list"] == ["Modus: Manual / Timer", "Modus: PPFD"]
+    assert light["effect_list"] == ["Manual", "Schedule", "PPFD"]
     assert light["command_topic"] == "spiderfarmer/ggs_1/command/light/set"
 
     assert "homeassistant/light/spiderfarmer_ggs_1_light2/config" in pubs
@@ -246,6 +246,7 @@ def test_fan_extras_grouped_into_sub_devices(mocker):
     assert sp["device"]["identifiers"] == ["spiderfarmer_ggs_1_fan_speeds"]
     assert sp["min"] == 1 and sp["max"] == 10
 
-    # Natural wind switch on main device
+    # Natural wind lives on the Speeds sub-device — same group as the
+    # other "applies across all modes" fan settings.
     nw = pubs["homeassistant/switch/spiderfarmer_ggs_1_fan_natural_wind/config"]
-    assert nw["device"]["identifiers"] == ["spiderfarmer_ggs_1"]
+    assert nw["device"]["identifiers"] == ["spiderfarmer_ggs_1_fan_speeds"]

--- a/spiderbridge/app/tests/test_discovery.py
+++ b/spiderbridge/app/tests/test_discovery.py
@@ -127,7 +127,8 @@ def test_publish_discovery_uses_retain_for_every_message(mocker):
 def test_publish_discovery_device_info_consistent(mocker):
     # Main entities live on the GGS controller; Fan Circulation settings
     # entities live on three sub-devices (Schedule Mode, Cycle Mode, Speeds)
-    # linked back via via_device.
+    # linked back via via_device. Light 1 adds two more sub-devices
+    # (Schedule Mode, PPFD Mode).
     client = mocker.MagicMock()
     publish_discovery_for_device(client, "ggs_1", CFG)
     pubs = _publish_calls(client)
@@ -139,6 +140,8 @@ def test_publish_discovery_device_info_consistent(mocker):
         ("spiderfarmer_ggs_1_fan_schedule",),
         ("spiderfarmer_ggs_1_fan_cycle",),
         ("spiderfarmer_ggs_1_fan_speeds",),
+        ("spiderfarmer_ggs_1_light_schedule",),
+        ("spiderfarmer_ggs_1_light_ppfd",),
     }
 
     for p in pubs.values():
@@ -219,6 +222,80 @@ def test_publish_discovery_emits_fan_extras(mocker):
     assert "homeassistant/number/spiderfarmer_ggs_1_fan_oscillation_level/config" in topics
     # Natural wind on main device (switch)
     assert "homeassistant/switch/spiderfarmer_ggs_1_fan_natural_wind/config" in topics
+
+
+def test_publish_discovery_emits_light_extras(mocker):
+    client = mocker.MagicMock()
+    publish_discovery_for_device(client, "ggs_1", CFG)
+    topics = {call.args[0] for call in client.publish.call_args_list}
+
+    # Schedule Mode sub-device
+    assert "homeassistant/number/spiderfarmer_ggs_1_light_schedule_brightness/config" in topics
+    assert "homeassistant/text/spiderfarmer_ggs_1_light_schedule_start/config" in topics
+    assert "homeassistant/text/spiderfarmer_ggs_1_light_schedule_end/config" in topics
+    assert "homeassistant/number/spiderfarmer_ggs_1_light_fade_minutes/config" in topics
+    # PPFD Mode sub-device
+    assert "homeassistant/number/spiderfarmer_ggs_1_light_ppfd_target/config" in topics
+    assert "homeassistant/number/spiderfarmer_ggs_1_light_ppfd_min/config" in topics
+    assert "homeassistant/number/spiderfarmer_ggs_1_light_ppfd_max/config" in topics
+    assert "homeassistant/text/spiderfarmer_ggs_1_light_ppfd_start/config" in topics
+    assert "homeassistant/text/spiderfarmer_ggs_1_light_ppfd_end/config" in topics
+    assert "homeassistant/number/spiderfarmer_ggs_1_light_ppfd_fade_minutes/config" in topics
+    # Temperaturschutz appears under BOTH sub-devices with distinct uids
+    assert "homeassistant/number/spiderfarmer_ggs_1_light_dim_threshold_schedule/config" in topics
+    assert "homeassistant/number/spiderfarmer_ggs_1_light_off_threshold_schedule/config" in topics
+    assert "homeassistant/number/spiderfarmer_ggs_1_light_dim_threshold_ppfd/config" in topics
+    assert "homeassistant/number/spiderfarmer_ggs_1_light_off_threshold_ppfd/config" in topics
+
+
+def test_light_extras_grouped_into_sub_devices(mocker):
+    client = mocker.MagicMock()
+    publish_discovery_for_device(client, "ggs_1", CFG)
+    pubs = _publish_calls(client)
+
+    # Schedule fields → Schedule Mode sub-device
+    sb = pubs["homeassistant/number/spiderfarmer_ggs_1_light_schedule_brightness/config"]
+    assert sb["device"]["identifiers"] == ["spiderfarmer_ggs_1_light_schedule"]
+    assert sb["device"]["via_device"] == "spiderfarmer_ggs_1"
+    assert sb["min"] == 0 and sb["max"] == 100
+    assert sb["unit_of_measurement"] == "%"
+
+    # PPFD fields → PPFD Mode sub-device
+    pt = pubs["homeassistant/number/spiderfarmer_ggs_1_light_ppfd_target/config"]
+    assert pt["device"]["identifiers"] == ["spiderfarmer_ggs_1_light_ppfd"]
+    assert pt["max"] == 1000
+    assert pt["unit_of_measurement"] == "µmol/m²/s"
+
+
+def test_light_temperaturschutz_appears_in_both_sub_devices_same_topics(mocker):
+    # Per user request, dim/off thresholds belong in both Schedule and PPFD
+    # cards (they apply in both modes). The two HA entities have distinct
+    # unique_ids but identical state/command topics so a single change
+    # keeps them in sync.
+    client = mocker.MagicMock()
+    publish_discovery_for_device(client, "ggs_1", CFG)
+    pubs = _publish_calls(client)
+
+    dim_sched = pubs["homeassistant/number/spiderfarmer_ggs_1_light_dim_threshold_schedule/config"]
+    dim_ppfd = pubs["homeassistant/number/spiderfarmer_ggs_1_light_dim_threshold_ppfd/config"]
+
+    assert dim_sched["device"]["identifiers"] == ["spiderfarmer_ggs_1_light_schedule"]
+    assert dim_ppfd["device"]["identifiers"] == ["spiderfarmer_ggs_1_light_ppfd"]
+    # Same wire topics so HA stays in sync
+    assert dim_sched["state_topic"] == dim_ppfd["state_topic"]
+    assert dim_sched["command_topic"] == dim_ppfd["command_topic"]
+    # Distinct unique_ids
+    assert dim_sched["unique_id"] != dim_ppfd["unique_id"]
+
+
+def test_light2_does_not_get_settings_sub_devices(mocker):
+    # Only Light 1 mirrors the SF App's settings screen. Light 2 stays as
+    # the simple light entity to keep the dashboard uncluttered.
+    client = mocker.MagicMock()
+    publish_discovery_for_device(client, "ggs_1", CFG)
+    topics = {call.args[0] for call in client.publish.call_args_list}
+
+    assert not any("light2_schedule" in t or "light2_ppfd" in t for t in topics)
 
 
 def test_fan_extras_grouped_into_sub_devices(mocker):

--- a/spiderbridge/app/tests/test_normalizer.py
+++ b/spiderbridge/app/tests/test_normalizer.py
@@ -30,20 +30,21 @@ def test_soil_avg_block_emits_top_level_topics():
     assert r["spiderfarmer/ggs_1/state/ec_soil"] == "1.5"
 
 
-def test_light_emits_json_payload_with_manual_mode():
+def test_light_emits_json_payload_with_schedule_mode():
     data = {"data": {"light": {"on": 1, "level": 80, "modeType": 1}}}
     r = normalize_status("ggs_1", data)
     p = json.loads(r["spiderfarmer/ggs_1/state/light"])
-    assert p == {"state": "ON", "brightness": 80, "effect": "Modus: Manual / Timer"}
+    assert p == {"state": "ON", "brightness": 80, "effect": "Schedule"}
 
 
-def test_light_mode_zero_also_displayed_as_manual():
-    # Controller reports modeType 0 (Manual) when the SF cloud or HA sets it
-    # to manual control. UI should still show a known effect, not the raw "0".
+def test_light_mode_zero_displays_as_manual():
+    # modeType 0 = "Manueller Modus" per SF App; modeType 1 is a different
+    # mode (Schedule / Zeitfenster). They must surface as distinct effects
+    # in HA so the dropdown reflects what the controller is actually doing.
     data = {"data": {"light": {"on": 1, "level": 80, "modeType": 0}}}
     r = normalize_status("ggs_1", data)
     p = json.loads(r["spiderfarmer/ggs_1/state/light"])
-    assert p["effect"] == "Modus: Manual / Timer"
+    assert p["effect"] == "Manual"
 
 
 def test_light_off_state():
@@ -57,7 +58,7 @@ def test_light2_ppfd_mode():
     data = {"data": {"light2": {"on": 1, "level": 50, "modeType": 12}}}
     r = normalize_status("ggs_1", data)
     p = json.loads(r["spiderfarmer/ggs_1/state/light2"])
-    assert p["effect"] == "Modus: PPFD"
+    assert p["effect"] == "PPFD"
 
 
 def test_light_controller_flat_schema_maps_to_light_topic():
@@ -69,7 +70,7 @@ def test_light_controller_flat_schema_maps_to_light_topic():
     p = json.loads(r["spiderfarmer/ggs_1/state/light"])
     assert p["state"] == "ON"
     assert p["brightness"] == 42
-    assert p["effect"] == "Modus: PPFD"
+    assert p["effect"] == "PPFD"
 
 
 def test_light_controller_flat_schema_off_when_brightness_zero():
@@ -93,7 +94,7 @@ def test_nested_light_takes_precedence_over_flat_lc_schema():
     r = normalize_status("ggs_1", data)
     p = json.loads(r["spiderfarmer/ggs_1/state/light"])
     assert p["brightness"] == 50
-    assert p["effect"] == "Modus: Manual / Timer"
+    assert p["effect"] == "Manual"
 
 
 def test_light_falls_back_to_mlevel_and_monoff_aliases():

--- a/spiderbridge/app/tests/test_normalizer.py
+++ b/spiderbridge/app/tests/test_normalizer.py
@@ -168,3 +168,58 @@ def test_on_off_value_variants():
     for off_val in (0, False, "0", "false", "off", "OFF"):
         d = {"data": {"heater": {"mOnOff": off_val}}}
         assert normalize_status("ggs_1", d)["spiderfarmer/ggs_1/state/heater"] == "OFF"
+
+
+# ── Fan app-parity (extra fields) ───────────────────────────────────────────
+
+def test_fan_emits_mode_label_and_schedule_extras():
+    data = {"data": {"fan": {
+        "modeType": 1, "mOnOff": 1, "mLevel": 3,
+        "shakeLevel": 6, "natural": 1,
+        "minSpeed": 2, "maxSpeed": 5,
+        "timePeriod": [{"enabled": 1, "weekmask": 127,
+                        "startTime": 21600, "endTime": 72000}],
+        "cycleTime": {"weekmask": 127},
+    }}}
+    r = normalize_status("ggs_1", data)
+    assert r["spiderfarmer/ggs_1/state/fan/mode_label"] == "Schedule"
+    assert r["spiderfarmer/ggs_1/state/fan/schedule_speed"] == "5"
+    assert r["spiderfarmer/ggs_1/state/fan/standby_speed"] == "2"
+    assert r["spiderfarmer/ggs_1/state/fan/oscillation_level"] == "6"
+    assert r["spiderfarmer/ggs_1/state/fan/natural_wind"] == "ON"
+    assert r["spiderfarmer/ggs_1/state/fan/schedule_start"] == "06:00"
+    assert r["spiderfarmer/ggs_1/state/fan/schedule_end"] == "20:00"
+
+
+def test_fan_emits_cycle_extras():
+    data = {"data": {"fan": {
+        "modeType": 2, "mOnOff": 1,
+        "cycleTime": {"weekmask": 127, "startTime": 10800,
+                      "openDur": 600, "closeDur": 1200, "times": 5},
+    }}}
+    r = normalize_status("ggs_1", data)
+    assert r["spiderfarmer/ggs_1/state/fan/mode_label"] == "Cycle"
+    assert r["spiderfarmer/ggs_1/state/fan/cycle_start"] == "03:00"
+    assert r["spiderfarmer/ggs_1/state/fan/cycle_run_minutes"] == "10"
+    assert r["spiderfarmer/ggs_1/state/fan/cycle_off_minutes"] == "20"
+    assert r["spiderfarmer/ggs_1/state/fan/cycle_times"] == "5"
+
+
+def test_fan_environment_modetypes_map_to_labels():
+    for mt, expected in [(7, "Environment: Prioritize temperature"),
+                         (8, "Environment: Prioritize humidity"),
+                         (3, "Environment: Temperature only"),
+                         (4, "Environment: Humidity only"),
+                         (13, "Environment: Temperature & humidity")]:
+        data = {"data": {"fan": {"modeType": mt}}}
+        r = normalize_status("ggs_1", data)
+        assert r["spiderfarmer/ggs_1/state/fan/mode_label"] == expected
+
+
+def test_blower_also_gets_extras():
+    data = {"data": {"blower": {
+        "modeType": 1, "maxSpeed": 50, "minSpeed": 25,
+    }}}
+    r = normalize_status("ggs_1", data)
+    assert r["spiderfarmer/ggs_1/state/blower/mode_label"] == "Schedule"
+    assert r["spiderfarmer/ggs_1/state/blower/schedule_speed"] == "50"

--- a/tests/test_command_handler.py
+++ b/tests/test_command_handler.py
@@ -225,3 +225,101 @@ def test_payload_includes_pid_uid_and_msg_id():
     # msgId is a string of millisecond timestamp
     assert isinstance(r["msgId"], str)
     assert int(r["msgId"]) > 0
+
+
+# ── Fan app-parity (preset_mode + subfield writes) ──────────────────────────
+
+def test_fan_preset_mode_maps_label_to_modeType():
+    cached = {"fan": {"modeType": 0, "mOnOff": 1, "mLevel": 3,
+                      "shakeLevel": 0, "natural": 0,
+                      "timePeriod": [{"weekmask": 127}],
+                      "cycleTime": {"weekmask": 127}}}
+    r = translate_command("fan", "Environment: Prioritize temperature",
+                          "AABBCC", "uid1",
+                          subfield="preset_mode", fan_state=cached)
+    assert r["params"]["fan"]["modeType"] == 7
+    # other fields preserved
+    assert r["params"]["fan"]["mLevel"] == 3
+    assert r["params"]["fan"]["shakeLevel"] == 0
+
+
+def test_fan_preset_mode_unknown_label_returns_none():
+    r = translate_command("fan", "Bogus Mode", "AABBCC", "uid1",
+                          subfield="preset_mode", fan_state={})
+    assert r is None
+
+
+def test_fan_schedule_start_parses_hhmm():
+    r = translate_command("fan", "07:30", "AABBCC", "uid1",
+                          subfield="schedule_start", fan_state={})
+    assert r["params"]["fan"]["timePeriod"][0]["startTime"] == 7 * 3600 + 30 * 60
+
+
+def test_fan_cycle_run_minutes_to_seconds():
+    r = translate_command("fan", "10", "AABBCC", "uid1",
+                          subfield="cycle_run_minutes", fan_state={})
+    assert r["params"]["fan"]["cycleTime"]["openDur"] == 600
+
+
+def test_fan_cycle_times_clamped_to_100():
+    r = translate_command("fan", "9999", "AABBCC", "uid1",
+                          subfield="cycle_times", fan_state={})
+    assert r["params"]["fan"]["cycleTime"]["times"] == 100
+
+
+def test_fan_schedule_speed_clamped_to_10():
+    r = translate_command("fan", "15", "AABBCC", "uid1",
+                          subfield="schedule_speed", fan_state={})
+    assert r["params"]["fan"]["maxSpeed"] == 10
+
+
+def test_fan_standby_speed_zero_means_aus():
+    r = translate_command("fan", "0", "AABBCC", "uid1",
+                          subfield="standby_speed", fan_state={})
+    assert r["params"]["fan"]["minSpeed"] == 0
+
+
+def test_fan_oscillation_level_writes_shake_level():
+    r = translate_command("fan", "7", "AABBCC", "uid1",
+                          subfield="oscillation_level", fan_state={})
+    assert r["params"]["fan"]["shakeLevel"] == 7
+
+
+def test_fan_natural_wind_on_off():
+    on = translate_command("fan", "ON", "AABBCC", "uid1",
+                           subfield="natural_wind", fan_state={})
+    off = translate_command("fan", "OFF", "AABBCC", "uid1",
+                            subfield="natural_wind", fan_state={})
+    assert on["params"]["fan"]["natural"] == 1
+    assert off["params"]["fan"]["natural"] == 0
+
+
+def test_fan_subfield_targets_blower_keypath_when_field_is_blower():
+    r = translate_command("blower", "5", "AABBCC", "uid1",
+                          subfield="schedule_speed", fan_state={})
+    assert r["params"]["keyPath"] == ["device", "blower"]
+    assert "blower" in r["params"]
+    assert r["params"]["blower"]["maxSpeed"] == 5
+
+
+def test_fan_subfield_preserves_cached_block_other_fields():
+    cached = {"fan": {
+        "modeType": 2, "mOnOff": 1, "mLevel": 3,
+        "shakeLevel": 6, "natural": 1,
+        "minSpeed": 1, "maxSpeed": 5,
+        "timePeriod": [{"enabled": 1, "weekmask": 127,
+                        "startTime": 3600, "endTime": 7200}],
+        "cycleTime": {"weekmask": 127, "startTime": 10800,
+                      "openDur": 600, "closeDur": 1200, "times": 5},
+    }}
+    r = translate_command("fan", "20", "AABBCC", "uid1",
+                          subfield="cycle_run_minutes", fan_state=cached)
+    out = r["params"]["fan"]
+    # Changed
+    assert out["cycleTime"]["openDur"] == 1200
+    # Untouched
+    assert out["cycleTime"]["closeDur"] == 1200
+    assert out["cycleTime"]["times"] == 5
+    assert out["modeType"] == 2
+    assert out["maxSpeed"] == 5
+    assert out["natural"] == 1

--- a/tests/test_command_handler.py
+++ b/tests/test_command_handler.py
@@ -327,6 +327,145 @@ def test_fan_subfield_targets_blower_keypath_when_field_is_blower():
     assert r["params"]["blower"]["maxSpeed"] == 5
 
 
+# ── Light app-parity (subfield writes) ─────────────────────────────────────
+
+def _light_block(**overrides):
+    """Realistic cached light block as observed from cloud setConfigField."""
+    blk = {
+        "modeType": 1, "lastAutoModeType": 0, "mOnOff": 1, "mLevel": 65,
+        "darkTemp": 0, "offTemp": 0,
+        "timePeriod": [{"enabled": 1, "weekmask": 127,
+                        "startTime": 21600, "endTime": 72000,
+                        "brightness": 65, "fadeTime": 900}],
+        "ppfdPeriod": [{"enabled": 0, "weekmask": 127,
+                        "startTime": 0, "endTime": 0,
+                        "brightness": 20, "fadeTime": 0}],
+        "ppfdMinBrightness": 0, "ppfdMaxBrightness": 100,
+    }
+    blk.update(overrides)
+    return {"light": blk}
+
+
+def test_light_schedule_brightness_subfield():
+    cached = _light_block()
+    r = translate_command("light", "80", "AABBCC", "uid1",
+                          subfield="schedule_brightness", light_state=cached)
+    assert r["params"]["keyPath"] == ["device", "light"]
+    assert r["params"]["light"]["timePeriod"][0]["brightness"] == 80
+
+
+def test_light_schedule_brightness_clamped():
+    r = translate_command("light", "999", "AABBCC", "uid1",
+                          subfield="schedule_brightness", light_state=_light_block())
+    assert r["params"]["light"]["timePeriod"][0]["brightness"] == 100
+
+
+def test_light_schedule_start_parses_hhmm():
+    r = translate_command("light", "06:30", "AABBCC", "uid1",
+                          subfield="schedule_start", light_state=_light_block())
+    assert r["params"]["light"]["timePeriod"][0]["startTime"] == 6 * 3600 + 30 * 60
+
+
+def test_light_schedule_end_parses_hhmm():
+    r = translate_command("light", "20:00", "AABBCC", "uid1",
+                          subfield="schedule_end", light_state=_light_block())
+    assert r["params"]["light"]["timePeriod"][0]["endTime"] == 20 * 3600
+
+
+def test_light_fade_minutes_to_seconds():
+    r = translate_command("light", "15", "AABBCC", "uid1",
+                          subfield="fade_minutes", light_state=_light_block())
+    assert r["params"]["light"]["timePeriod"][0]["fadeTime"] == 900
+
+
+def test_light_dim_threshold_writes_dark_temp():
+    r = translate_command("light", "27.5", "AABBCC", "uid1",
+                          subfield="dim_threshold", light_state=_light_block())
+    assert r["params"]["light"]["darkTemp"] == 27.5
+
+
+def test_light_off_threshold_writes_off_temp():
+    r = translate_command("light", "30", "AABBCC", "uid1",
+                          subfield="off_threshold", light_state=_light_block())
+    assert r["params"]["light"]["offTemp"] == 30.0
+
+
+def test_light_ppfd_target_writes_ppfd_period_brightness():
+    r = translate_command("light", "650", "AABBCC", "uid1",
+                          subfield="ppfd_target", light_state=_light_block())
+    assert r["params"]["light"]["ppfdPeriod"][0]["brightness"] == 650
+
+
+def test_light_ppfd_target_clamped_to_1000():
+    r = translate_command("light", "9999", "AABBCC", "uid1",
+                          subfield="ppfd_target", light_state=_light_block())
+    assert r["params"]["light"]["ppfdPeriod"][0]["brightness"] == 1000
+
+
+def test_light_ppfd_min_max_clamped_to_100():
+    rmin = translate_command("light", "150", "AABBCC", "uid1",
+                             subfield="ppfd_min", light_state=_light_block())
+    rmax = translate_command("light", "200", "AABBCC", "uid1",
+                             subfield="ppfd_max", light_state=_light_block())
+    assert rmin["params"]["light"]["ppfdMinBrightness"] == 100
+    assert rmax["params"]["light"]["ppfdMaxBrightness"] == 100
+
+
+def test_light_ppfd_start_end_parses_hhmm():
+    rs = translate_command("light", "07:15", "AABBCC", "uid1",
+                           subfield="ppfd_start", light_state=_light_block())
+    re = translate_command("light", "19:45", "AABBCC", "uid1",
+                           subfield="ppfd_end", light_state=_light_block())
+    assert rs["params"]["light"]["ppfdPeriod"][0]["startTime"] == 7 * 3600 + 15 * 60
+    assert re["params"]["light"]["ppfdPeriod"][0]["endTime"] == 19 * 3600 + 45 * 60
+
+
+def test_light_ppfd_fade_minutes_to_seconds():
+    r = translate_command("light", "5", "AABBCC", "uid1",
+                          subfield="ppfd_fade_minutes", light_state=_light_block())
+    assert r["params"]["light"]["ppfdPeriod"][0]["fadeTime"] == 300
+
+
+def test_light_subfield_with_empty_cache_synthesizes_default_block():
+    # No cached block — translator must still produce a valid setConfigField.
+    # Otherwise the controller silently rejects partial writes.
+    r = translate_command("light", "07:00", "AABBCC", "uid1",
+                          subfield="schedule_start", light_state={})
+    assert r is not None
+    blk = r["params"]["light"]
+    assert blk["timePeriod"][0]["startTime"] == 7 * 3600
+    # Synthesized defaults present
+    assert "ppfdPeriod" in blk
+    assert "darkTemp" in blk
+
+
+def test_light_subfield_preserves_cached_block_other_fields():
+    cached = _light_block(modeType=12, mLevel=50)
+    r = translate_command("light", "55", "AABBCC", "uid1",
+                          subfield="ppfd_min", light_state=cached)
+    out = r["params"]["light"]
+    # Changed
+    assert out["ppfdMinBrightness"] == 55
+    # Untouched
+    assert out["modeType"] == 12
+    assert out["mLevel"] == 50
+    assert out["timePeriod"][0]["brightness"] == 65
+
+
+def test_light2_subfield_targets_light2_keypath():
+    r = translate_command("light2", "08:00", "AABBCC", "uid1",
+                          subfield="schedule_start",
+                          light_state={"light2": {"timePeriod": [{}]}})
+    assert r["params"]["keyPath"] == ["device", "light2"]
+    assert "light2" in r["params"]
+
+
+def test_light_invalid_numeric_subfield_returns_none():
+    r = translate_command("light", "abc", "AABBCC", "uid1",
+                          subfield="schedule_brightness", light_state=_light_block())
+    assert r is None
+
+
 def test_fan_subfield_preserves_cached_block_other_fields():
     cached = {"fan": {
         "modeType": 2, "mOnOff": 1, "mLevel": 3,

--- a/tests/test_command_handler.py
+++ b/tests/test_command_handler.py
@@ -23,7 +23,7 @@ def test_outlet_off():
 # ── Light / Light2 ──────────────────────────────────────────────────────────
 
 def test_light_full_json_payload_with_ppfd_mode():
-    val = json.dumps({"state": "ON", "brightness": 80, "effect": "Modus: PPFD"})
+    val = json.dumps({"state": "ON", "brightness": 80, "effect": "PPFD"})
     r = translate_command("light", val, "AABBCC", "uid1")
     assert r["params"]["keyPath"] == ["device", "light"]
     assert r["params"]["light"]["mOnOff"] == 1
@@ -32,14 +32,29 @@ def test_light_full_json_payload_with_ppfd_mode():
 
 
 def test_light2_full_json_payload_with_manual_mode():
-    # "Modus: Manual / Timer" effect maps to modeType 0 (Manual). Sending
-    # modeType 1 (Timer) makes the controller follow the schedule and ignore
-    # direct mOnOff/mLevel commands, which broke HA control of the lamp.
-    val = json.dumps({"state": "ON", "brightness": 50, "effect": "Modus: Manual / Timer"})
+    val = json.dumps({"state": "ON", "brightness": 50, "effect": "Manual"})
     r = translate_command("light2", val, "AABBCC", "uid1")
     assert r["params"]["keyPath"] == ["device", "light2"]
     assert r["params"]["light2"]["modeType"] == 0
     assert r["params"]["light2"]["mLevel"] == 50
+
+
+def test_light_schedule_mode_maps_to_modeType_1():
+    # "Schedule" effect must produce modeType=1 (Zeitfenstermodus); older
+    # code merged 0 and 1 under one label which made schedule-mode
+    # selection a no-op.
+    val = json.dumps({"state": "ON", "brightness": 70, "effect": "Schedule"})
+    r = translate_command("light", val, "AABBCC", "uid1")
+    assert r["params"]["light"]["modeType"] == 1
+
+
+def test_light_legacy_effect_label_still_resolves_to_manual():
+    # Old HA configs that have "Modus: Manual / Timer" stored as the effect
+    # should still work after the rename — the alias keeps them on
+    # modeType=0 instead of falling through to the default.
+    val = json.dumps({"state": "ON", "effect": "Modus: Manual / Timer"})
+    r = translate_command("light", val, "AABBCC", "uid1")
+    assert r["params"]["light"]["modeType"] == 0
 
 
 def test_light_default_mode_is_manual():

--- a/tests/test_command_handler.py
+++ b/tests/test_command_handler.py
@@ -273,6 +273,16 @@ def test_fan_schedule_speed_clamped_to_10():
     assert r["params"]["fan"]["maxSpeed"] == 10
 
 
+def test_fan_schedule_speed_also_writes_mlevel_for_manual_mode():
+    # Manual mode reads mLevel, Schedule/Cycle/Env modes read maxSpeed.
+    # The single HA "Speed" entity must change the fan regardless of
+    # which mode is currently active, so we set both.
+    r = translate_command("fan", "5", "AABBCC", "uid1",
+                          subfield="schedule_speed", fan_state={})
+    assert r["params"]["fan"]["maxSpeed"] == 5
+    assert r["params"]["fan"]["mLevel"] == 5
+
+
 def test_fan_standby_speed_zero_means_aus():
     r = translate_command("fan", "0", "AABBCC", "uid1",
                           subfield="standby_speed", fan_state={})

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -125,17 +125,30 @@ def test_publish_discovery_uses_retain_for_every_message(mocker):
 
 
 def test_publish_discovery_device_info_consistent(mocker):
+    # Main entities live on the GGS controller; Fan Circulation settings
+    # entities live on three sub-devices (Schedule Mode, Cycle Mode, Speeds)
+    # linked back via via_device.
     client = mocker.MagicMock()
     publish_discovery_for_device(client, "ggs_1", CFG)
     pubs = _publish_calls(client)
 
     seen = {tuple(p["device"]["identifiers"]) for p in pubs.values()}
-    assert seen == {("spiderfarmer_ggs_1",)}
+    assert ("spiderfarmer_ggs_1",) in seen
+    sub_ids = {ids for ids in seen if ids != ("spiderfarmer_ggs_1",)}
+    assert sub_ids == {
+        ("spiderfarmer_ggs_1_fan_schedule",),
+        ("spiderfarmer_ggs_1_fan_cycle",),
+        ("spiderfarmer_ggs_1_fan_speeds",),
+    }
 
     for p in pubs.values():
+        ids = tuple(p["device"]["identifiers"])
         assert p["device"]["manufacturer"] == "Spider Farmer"
-        assert p["device"]["model"] == "GGS Controller"
-        assert p["device"]["name"] == "Test GGS"
+        if ids == ("spiderfarmer_ggs_1",):
+            assert p["device"]["model"] == "GGS Controller"
+            assert p["device"]["name"] == "Test GGS"
+        else:
+            assert p["device"]["via_device"] == "spiderfarmer_ggs_1"
 
 
 def test_unpublish_outlet_discovery_sends_empty_retained_payload(mocker):
@@ -170,3 +183,69 @@ def test_publish_soil_sensor_discovery_emits_three_entities(mocker):
     assert ec_topic in pubs
     assert "device_class" not in pubs[ec_topic]
     assert pubs[ec_topic]["unit_of_measurement"] == "mS/cm"
+
+
+def test_publish_discovery_emits_fan_preset_modes(mocker):
+    client = mocker.MagicMock()
+    publish_discovery_for_device(client, "ggs_1", CFG)
+    pubs = _publish_calls(client)
+
+    fan = pubs["homeassistant/fan/spiderfarmer_ggs_1_fan/config"]
+    assert fan["preset_mode_state_topic"] == "spiderfarmer/ggs_1/state/fan/mode_label"
+    assert fan["preset_mode_command_topic"] == "spiderfarmer/ggs_1/command/fan/preset_mode/set"
+    assert "Manual" in fan["preset_modes"]
+    assert "Schedule" in fan["preset_modes"]
+    assert "Cycle" in fan["preset_modes"]
+    assert "Environment: Prioritize temperature" in fan["preset_modes"]
+    assert len(fan["preset_modes"]) == 8
+
+
+def test_publish_discovery_emits_fan_extras(mocker):
+    client = mocker.MagicMock()
+    publish_discovery_for_device(client, "ggs_1", CFG)
+    topics = {call.args[0] for call in client.publish.call_args_list}
+
+    # Schedule Mode sub-device
+    assert "homeassistant/text/spiderfarmer_ggs_1_fan_schedule_start/config" in topics
+    assert "homeassistant/text/spiderfarmer_ggs_1_fan_schedule_end/config" in topics
+    # Cycle Mode sub-device
+    assert "homeassistant/text/spiderfarmer_ggs_1_fan_cycle_start/config" in topics
+    assert "homeassistant/number/spiderfarmer_ggs_1_fan_cycle_run_minutes/config" in topics
+    assert "homeassistant/number/spiderfarmer_ggs_1_fan_cycle_off_minutes/config" in topics
+    assert "homeassistant/number/spiderfarmer_ggs_1_fan_cycle_times/config" in topics
+    # Speeds sub-device
+    assert "homeassistant/number/spiderfarmer_ggs_1_fan_schedule_speed/config" in topics
+    assert "homeassistant/number/spiderfarmer_ggs_1_fan_standby_speed/config" in topics
+    assert "homeassistant/number/spiderfarmer_ggs_1_fan_oscillation_level/config" in topics
+    # Natural wind on main device (switch)
+    assert "homeassistant/switch/spiderfarmer_ggs_1_fan_natural_wind/config" in topics
+
+
+def test_fan_extras_grouped_into_sub_devices(mocker):
+    client = mocker.MagicMock()
+    publish_discovery_for_device(client, "ggs_1", CFG)
+    pubs = _publish_calls(client)
+
+    # Schedule fields → Schedule Mode sub-device
+    ss = pubs["homeassistant/text/spiderfarmer_ggs_1_fan_schedule_start/config"]
+    assert ss["device"]["identifiers"] == ["spiderfarmer_ggs_1_fan_schedule"]
+    assert ss["device"]["via_device"] == "spiderfarmer_ggs_1"
+
+    # Cycle fields → Cycle Mode sub-device
+    cr = pubs["homeassistant/number/spiderfarmer_ggs_1_fan_cycle_run_minutes/config"]
+    assert cr["device"]["identifiers"] == ["spiderfarmer_ggs_1_fan_cycle"]
+    assert cr["unit_of_measurement"] == "min"
+    assert cr["max"] == 1440
+
+    # Cycle times max 100 (controller cap)
+    ct = pubs["homeassistant/number/spiderfarmer_ggs_1_fan_cycle_times/config"]
+    assert ct["max"] == 100
+
+    # Speed fields → Speeds sub-device
+    sp = pubs["homeassistant/number/spiderfarmer_ggs_1_fan_schedule_speed/config"]
+    assert sp["device"]["identifiers"] == ["spiderfarmer_ggs_1_fan_speeds"]
+    assert sp["min"] == 1 and sp["max"] == 10
+
+    # Natural wind switch on main device
+    nw = pubs["homeassistant/switch/spiderfarmer_ggs_1_fan_natural_wind/config"]
+    assert nw["device"]["identifiers"] == ["spiderfarmer_ggs_1"]

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -46,7 +46,7 @@ def test_publish_discovery_emits_lights_with_effect_list(mocker):
     assert light["schema"] == "json"
     assert light["brightness"] is True
     assert light["brightness_scale"] == 100
-    assert light["effect_list"] == ["Modus: Manual / Timer", "Modus: PPFD"]
+    assert light["effect_list"] == ["Manual", "Schedule", "PPFD"]
     assert light["command_topic"] == "spiderfarmer/ggs_1/command/light/set"
 
     assert "homeassistant/light/spiderfarmer_ggs_1_light2/config" in pubs
@@ -246,6 +246,7 @@ def test_fan_extras_grouped_into_sub_devices(mocker):
     assert sp["device"]["identifiers"] == ["spiderfarmer_ggs_1_fan_speeds"]
     assert sp["min"] == 1 and sp["max"] == 10
 
-    # Natural wind switch on main device
+    # Natural wind lives on the Speeds sub-device — same group as the
+    # other "applies across all modes" fan settings.
     nw = pubs["homeassistant/switch/spiderfarmer_ggs_1_fan_natural_wind/config"]
-    assert nw["device"]["identifiers"] == ["spiderfarmer_ggs_1"]
+    assert nw["device"]["identifiers"] == ["spiderfarmer_ggs_1_fan_speeds"]

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -127,7 +127,8 @@ def test_publish_discovery_uses_retain_for_every_message(mocker):
 def test_publish_discovery_device_info_consistent(mocker):
     # Main entities live on the GGS controller; Fan Circulation settings
     # entities live on three sub-devices (Schedule Mode, Cycle Mode, Speeds)
-    # linked back via via_device.
+    # linked back via via_device. Light 1 adds two more sub-devices
+    # (Schedule Mode, PPFD Mode).
     client = mocker.MagicMock()
     publish_discovery_for_device(client, "ggs_1", CFG)
     pubs = _publish_calls(client)
@@ -139,6 +140,8 @@ def test_publish_discovery_device_info_consistent(mocker):
         ("spiderfarmer_ggs_1_fan_schedule",),
         ("spiderfarmer_ggs_1_fan_cycle",),
         ("spiderfarmer_ggs_1_fan_speeds",),
+        ("spiderfarmer_ggs_1_light_schedule",),
+        ("spiderfarmer_ggs_1_light_ppfd",),
     }
 
     for p in pubs.values():
@@ -219,6 +222,80 @@ def test_publish_discovery_emits_fan_extras(mocker):
     assert "homeassistant/number/spiderfarmer_ggs_1_fan_oscillation_level/config" in topics
     # Natural wind on main device (switch)
     assert "homeassistant/switch/spiderfarmer_ggs_1_fan_natural_wind/config" in topics
+
+
+def test_publish_discovery_emits_light_extras(mocker):
+    client = mocker.MagicMock()
+    publish_discovery_for_device(client, "ggs_1", CFG)
+    topics = {call.args[0] for call in client.publish.call_args_list}
+
+    # Schedule Mode sub-device
+    assert "homeassistant/number/spiderfarmer_ggs_1_light_schedule_brightness/config" in topics
+    assert "homeassistant/text/spiderfarmer_ggs_1_light_schedule_start/config" in topics
+    assert "homeassistant/text/spiderfarmer_ggs_1_light_schedule_end/config" in topics
+    assert "homeassistant/number/spiderfarmer_ggs_1_light_fade_minutes/config" in topics
+    # PPFD Mode sub-device
+    assert "homeassistant/number/spiderfarmer_ggs_1_light_ppfd_target/config" in topics
+    assert "homeassistant/number/spiderfarmer_ggs_1_light_ppfd_min/config" in topics
+    assert "homeassistant/number/spiderfarmer_ggs_1_light_ppfd_max/config" in topics
+    assert "homeassistant/text/spiderfarmer_ggs_1_light_ppfd_start/config" in topics
+    assert "homeassistant/text/spiderfarmer_ggs_1_light_ppfd_end/config" in topics
+    assert "homeassistant/number/spiderfarmer_ggs_1_light_ppfd_fade_minutes/config" in topics
+    # Temperaturschutz appears under BOTH sub-devices with distinct uids
+    assert "homeassistant/number/spiderfarmer_ggs_1_light_dim_threshold_schedule/config" in topics
+    assert "homeassistant/number/spiderfarmer_ggs_1_light_off_threshold_schedule/config" in topics
+    assert "homeassistant/number/spiderfarmer_ggs_1_light_dim_threshold_ppfd/config" in topics
+    assert "homeassistant/number/spiderfarmer_ggs_1_light_off_threshold_ppfd/config" in topics
+
+
+def test_light_extras_grouped_into_sub_devices(mocker):
+    client = mocker.MagicMock()
+    publish_discovery_for_device(client, "ggs_1", CFG)
+    pubs = _publish_calls(client)
+
+    # Schedule fields → Schedule Mode sub-device
+    sb = pubs["homeassistant/number/spiderfarmer_ggs_1_light_schedule_brightness/config"]
+    assert sb["device"]["identifiers"] == ["spiderfarmer_ggs_1_light_schedule"]
+    assert sb["device"]["via_device"] == "spiderfarmer_ggs_1"
+    assert sb["min"] == 0 and sb["max"] == 100
+    assert sb["unit_of_measurement"] == "%"
+
+    # PPFD fields → PPFD Mode sub-device
+    pt = pubs["homeassistant/number/spiderfarmer_ggs_1_light_ppfd_target/config"]
+    assert pt["device"]["identifiers"] == ["spiderfarmer_ggs_1_light_ppfd"]
+    assert pt["max"] == 1000
+    assert pt["unit_of_measurement"] == "µmol/m²/s"
+
+
+def test_light_temperaturschutz_appears_in_both_sub_devices_same_topics(mocker):
+    # Per user request, dim/off thresholds belong in both Schedule and PPFD
+    # cards (they apply in both modes). The two HA entities have distinct
+    # unique_ids but identical state/command topics so a single change
+    # keeps them in sync.
+    client = mocker.MagicMock()
+    publish_discovery_for_device(client, "ggs_1", CFG)
+    pubs = _publish_calls(client)
+
+    dim_sched = pubs["homeassistant/number/spiderfarmer_ggs_1_light_dim_threshold_schedule/config"]
+    dim_ppfd = pubs["homeassistant/number/spiderfarmer_ggs_1_light_dim_threshold_ppfd/config"]
+
+    assert dim_sched["device"]["identifiers"] == ["spiderfarmer_ggs_1_light_schedule"]
+    assert dim_ppfd["device"]["identifiers"] == ["spiderfarmer_ggs_1_light_ppfd"]
+    # Same wire topics so HA stays in sync
+    assert dim_sched["state_topic"] == dim_ppfd["state_topic"]
+    assert dim_sched["command_topic"] == dim_ppfd["command_topic"]
+    # Distinct unique_ids
+    assert dim_sched["unique_id"] != dim_ppfd["unique_id"]
+
+
+def test_light2_does_not_get_settings_sub_devices(mocker):
+    # Only Light 1 mirrors the SF App's settings screen. Light 2 stays as
+    # the simple light entity to keep the dashboard uncluttered.
+    client = mocker.MagicMock()
+    publish_discovery_for_device(client, "ggs_1", CFG)
+    topics = {call.args[0] for call in client.publish.call_args_list}
+
+    assert not any("light2_schedule" in t or "light2_ppfd" in t for t in topics)
 
 
 def test_fan_extras_grouped_into_sub_devices(mocker):

--- a/tests/test_normalizer.py
+++ b/tests/test_normalizer.py
@@ -30,20 +30,21 @@ def test_soil_avg_block_emits_top_level_topics():
     assert r["spiderfarmer/ggs_1/state/ec_soil"] == "1.5"
 
 
-def test_light_emits_json_payload_with_manual_mode():
+def test_light_emits_json_payload_with_schedule_mode():
     data = {"data": {"light": {"on": 1, "level": 80, "modeType": 1}}}
     r = normalize_status("ggs_1", data)
     p = json.loads(r["spiderfarmer/ggs_1/state/light"])
-    assert p == {"state": "ON", "brightness": 80, "effect": "Modus: Manual / Timer"}
+    assert p == {"state": "ON", "brightness": 80, "effect": "Schedule"}
 
 
-def test_light_mode_zero_also_displayed_as_manual():
-    # Controller reports modeType 0 (Manual) when the SF cloud or HA sets it
-    # to manual control. UI should still show a known effect, not the raw "0".
+def test_light_mode_zero_displays_as_manual():
+    # modeType 0 = "Manueller Modus" per SF App; modeType 1 is a different
+    # mode (Schedule / Zeitfenster). They must surface as distinct effects
+    # in HA so the dropdown reflects what the controller is actually doing.
     data = {"data": {"light": {"on": 1, "level": 80, "modeType": 0}}}
     r = normalize_status("ggs_1", data)
     p = json.loads(r["spiderfarmer/ggs_1/state/light"])
-    assert p["effect"] == "Modus: Manual / Timer"
+    assert p["effect"] == "Manual"
 
 
 def test_light_off_state():
@@ -57,7 +58,7 @@ def test_light2_ppfd_mode():
     data = {"data": {"light2": {"on": 1, "level": 50, "modeType": 12}}}
     r = normalize_status("ggs_1", data)
     p = json.loads(r["spiderfarmer/ggs_1/state/light2"])
-    assert p["effect"] == "Modus: PPFD"
+    assert p["effect"] == "PPFD"
 
 
 def test_light_controller_flat_schema_maps_to_light_topic():
@@ -69,7 +70,7 @@ def test_light_controller_flat_schema_maps_to_light_topic():
     p = json.loads(r["spiderfarmer/ggs_1/state/light"])
     assert p["state"] == "ON"
     assert p["brightness"] == 42
-    assert p["effect"] == "Modus: PPFD"
+    assert p["effect"] == "PPFD"
 
 
 def test_light_controller_flat_schema_off_when_brightness_zero():
@@ -93,7 +94,7 @@ def test_nested_light_takes_precedence_over_flat_lc_schema():
     r = normalize_status("ggs_1", data)
     p = json.loads(r["spiderfarmer/ggs_1/state/light"])
     assert p["brightness"] == 50
-    assert p["effect"] == "Modus: Manual / Timer"
+    assert p["effect"] == "Manual"
 
 
 def test_light_falls_back_to_mlevel_and_monoff_aliases():

--- a/tests/test_normalizer.py
+++ b/tests/test_normalizer.py
@@ -168,3 +168,58 @@ def test_on_off_value_variants():
     for off_val in (0, False, "0", "false", "off", "OFF"):
         d = {"data": {"heater": {"mOnOff": off_val}}}
         assert normalize_status("ggs_1", d)["spiderfarmer/ggs_1/state/heater"] == "OFF"
+
+
+# ── Fan app-parity (extra fields) ───────────────────────────────────────────
+
+def test_fan_emits_mode_label_and_schedule_extras():
+    data = {"data": {"fan": {
+        "modeType": 1, "mOnOff": 1, "mLevel": 3,
+        "shakeLevel": 6, "natural": 1,
+        "minSpeed": 2, "maxSpeed": 5,
+        "timePeriod": [{"enabled": 1, "weekmask": 127,
+                        "startTime": 21600, "endTime": 72000}],
+        "cycleTime": {"weekmask": 127},
+    }}}
+    r = normalize_status("ggs_1", data)
+    assert r["spiderfarmer/ggs_1/state/fan/mode_label"] == "Schedule"
+    assert r["spiderfarmer/ggs_1/state/fan/schedule_speed"] == "5"
+    assert r["spiderfarmer/ggs_1/state/fan/standby_speed"] == "2"
+    assert r["spiderfarmer/ggs_1/state/fan/oscillation_level"] == "6"
+    assert r["spiderfarmer/ggs_1/state/fan/natural_wind"] == "ON"
+    assert r["spiderfarmer/ggs_1/state/fan/schedule_start"] == "06:00"
+    assert r["spiderfarmer/ggs_1/state/fan/schedule_end"] == "20:00"
+
+
+def test_fan_emits_cycle_extras():
+    data = {"data": {"fan": {
+        "modeType": 2, "mOnOff": 1,
+        "cycleTime": {"weekmask": 127, "startTime": 10800,
+                      "openDur": 600, "closeDur": 1200, "times": 5},
+    }}}
+    r = normalize_status("ggs_1", data)
+    assert r["spiderfarmer/ggs_1/state/fan/mode_label"] == "Cycle"
+    assert r["spiderfarmer/ggs_1/state/fan/cycle_start"] == "03:00"
+    assert r["spiderfarmer/ggs_1/state/fan/cycle_run_minutes"] == "10"
+    assert r["spiderfarmer/ggs_1/state/fan/cycle_off_minutes"] == "20"
+    assert r["spiderfarmer/ggs_1/state/fan/cycle_times"] == "5"
+
+
+def test_fan_environment_modetypes_map_to_labels():
+    for mt, expected in [(7, "Environment: Prioritize temperature"),
+                         (8, "Environment: Prioritize humidity"),
+                         (3, "Environment: Temperature only"),
+                         (4, "Environment: Humidity only"),
+                         (13, "Environment: Temperature & humidity")]:
+        data = {"data": {"fan": {"modeType": mt}}}
+        r = normalize_status("ggs_1", data)
+        assert r["spiderfarmer/ggs_1/state/fan/mode_label"] == expected
+
+
+def test_blower_also_gets_extras():
+    data = {"data": {"blower": {
+        "modeType": 1, "maxSpeed": 50, "minSpeed": 25,
+    }}}
+    r = normalize_status("ggs_1", data)
+    assert r["spiderfarmer/ggs_1/state/blower/mode_label"] == "Schedule"
+    assert r["spiderfarmer/ggs_1/state/blower/schedule_speed"] == "50"


### PR DESCRIPTION
## Summary

Mirrors the SF App's Lüfter- and Lampe-Einstellungen screens in Home
Assistant. Each entity maps to one field on the controller's
`fan` / `blower` / `light` block via `setConfigField`.

- **Fan Circulation:** preset_mode dropdown (8 modes incl. 5 Umwelt
  variants) + 3 settings sub-devices (Schedule Mode, Cycle Mode,
  Speeds — natural_wind lives under Speeds).
- **Light 1:** 2 settings sub-devices (Schedule Mode, PPFD Mode).
  Temperaturschutz (dim/off threshold) appears in both cards with
  distinct unique_ids but shared wire topics so they stay in sync.
- **Periodic config polling:** one immediate `getConfigField` poll
  on session connect + every 10 minutes thereafter, so HA caches
  refresh after restart/reconnect without waiting for cloud traffic.
- **Light effect dropdown:** modeType cache (from observed cloud
  setConfigField + own injects) so the dropdown reflects the
  controller's actual mode even when `getDevSta` omits modeType.
- **Manual-mode Speed fix:** `schedule_speed` now writes both
  `maxSpeed` and `mLevel` so a single HA Speed entity controls the
  fan in every mode.
- **Cache + synthesize fallback** in command_handler so partial
  subfield writes round-trip cleanly even when the cloud has not
  pushed a setConfigField for the module yet.
- **Docs:** `docs/extending.md` — recipe for adding the next module
  with the fan/light branches as worked examples. Pairs with
  `docs/sf-protocol.md`.

Standalone (`proxy/`, `ha/`) and addon (`spiderbridge/app/...`) paths
both updated. 111 standalone + 115 addon tests green.

## Test plan
- [x] Unit tests cover normalizer, command_handler, discovery for both new modules
- [x] Both test suites pass (standalone + addon)
- [ ] Verify on real device: HA shows Light 1 Schedule + PPFD cards, Fan Schedule/Cycle/Speeds cards
- [ ] Click each new entity from HA, confirm controller executes (proxy logs setConfigField)
- [ ] Change same setting from SF App, confirm HA updates within seconds
- [ ] Wait 10 min after restart — confirm config poll repopulates HA values

🤖 Generated with [Claude Code](https://claude.com/claude-code)